### PR TITLE
Gh4 fix not exiting after mapping

### DIFF
--- a/lib/collectionspace_migration_tools/build/log_client.rb
+++ b/lib/collectionspace_migration_tools/build/log_client.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'aws-sdk-cloudwatchlogs'
+
+module CollectionspaceMigrationTools
+  module Build
+  # Returns AWS CloudWatchLog client
+    class LogClient
+      include Dry::Monads[:result]
+      include Dry::Monads::Do.for(:call)
+      
+      class << self
+        def call()
+          self.new.call
+        end
+      end
+
+      def initialize
+        @key = CMT.config.client.s3_key
+        @secret = CMT.config.client.s3_secret
+        @region = CMT.config.client.s3_region
+      end
+
+      def call
+        client = yield(create_client)
+        _try = yield(try(client))
+
+        Success(client)
+      end
+      
+      private
+
+      attr_reader :key, :secret, :region
+
+      def create_client
+        client = Aws::CloudWatchLogs::Client.new(
+          access_key_id: key,
+          secret_access_key: secret,
+          region: region
+        )
+      rescue StandardError => err
+        msg = "#{err.message} IN #{err.backtrace[0]}"
+        Failure(CMT::Failure.new(context: "#{self.class.name}.#{__callee__}", message: msg))
+      else
+        Success(client)
+      end
+
+      def try(client)
+        binding.pry
+        result = client.get_bucket_location({bucket: bucket})
+      rescue StandardError => err
+        msg = "#{err.message} IN #{err.backtrace[0]}"
+        Failure(CMT::Failure.new(context: "#{self.class.name}.#{__callee__}", message: msg))
+      else
+        Success(result)
+      end
+    end
+  end
+end

--- a/lib/collectionspace_migration_tools/tunnel.rb
+++ b/lib/collectionspace_migration_tools/tunnel.rb
@@ -23,7 +23,8 @@ module CollectionspaceMigrationTools
     def status
       result = `ps -o pid -o ppid -o command`
         .split("\n")
-        .select{ |process| process.start_with?("#{pid} #{Process.pid} ssh -N -L") }
+        .map(&:strip)
+        .select{ |process| process.start_with?(/#{pid} +#{Process.pid} +ssh -N -L/) }
       result.empty? ? :closed : :open
     end
   end


### PR DESCRIPTION
Closes #4 

Application was not exiting because tunnel was not closed. 

Tunnel was not closed because status was actually open, but was reported by `Tunnel.status` as closed. 

`Tunnel.status` reported closed because it was not taking into account space padding in `ps` results. 
