### PR TITLE
Remove db config validation constraint on `bastion-host` value

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -22,6 +22,7 @@ These changes are merged into the `main` branch, but have not been released. Aft
 === Bugfixes
 
 === Deleted
+* Config validation constraint requiring `bastion-host` value to contain `bastion`. The host for tunneling for a project I am working on does not contain `bastion`
 
 === Deprecated/Will break in a future version
 

--- a/lib/collectionspace_migration_tools/validate/config_database_contract.rb
+++ b/lib/collectionspace_migration_tools/validate/config_database_contract.rb
@@ -19,10 +19,6 @@ module CollectionspaceMigrationTools
       rule(:db_host) do
         key.failure(%(must not contain "-bastion")) if value['-bastion']
       end
-
-      rule(:bastion_host) do
-        key.failure(%(must contain "-bastion")) unless value['-bastion']
-      end
     end
   end
 end


### PR DESCRIPTION
The host I tunnel through for an active project does not contain `bastion`. 

Further, if you switch the `bastion-host` and `db-host` values in a config, you aren't going to be able to connect to the db, so you will likely figure this issue out real soon without the validation holding your hand.