### PR TITLE
Media ingest improvements

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -27,6 +27,16 @@ These changes are merged into the `main` branch, but have not been released. Aft
 
 === Deprecated/Will break in a future version
 
+== 1.0.0 (2022-12-06)
+This is not a breaking change, but reflects this is now being used for CS migrations by more than one person.
+
+=== Added
+* When mapping a batch with `rectype=media`, rows with `blob_uri` values that cannot be converted into `URI` objects will get a "media_uri cannot be encoded as valid ingest URI. File ingest may not work as expected" warning.
+* `thor decode objects` that decodes object keys of all objects in S3 bucket, writing the results to a CSV in your base directory
+* `thor media blob_data` command to write report of all media procedures and, if present, their blob details
+* `thor media deriv_report` command to generate report of derivatives present for each `blobcsid` given
+* `:media_with_blob_upload_delay` client config setting, and implemented specified post-item-upload delay for media records with blob mediaFileURI values
+
 == 0.1.2 (2022-12-02)
 * Use `collectionspace-mapper` v4.1.2 to get error handling bugfix
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -220,7 +220,7 @@ GEM
     rspec-mocks (3.11.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
-    rspec-support (3.11.0)
+    rspec-support (3.11.1)
     rubocop (1.25.1)
       parallel (~> 1.10)
       parser (>= 3.1.0.0)

--- a/doc/media.adoc
+++ b/doc/media.adoc
@@ -1,0 +1,105 @@
+:toc:
+:toc-placement!:
+:toclevels: 4
+
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
+= Media handling procedures with blobs
+
+toc::[]
+
+You can transfer media and import files by including a URI in `mediaFileURI` column of your CSV. This works for:
+
+* new media records created
+* existing media records updated -- If existing media records have blobs attached they will be unattached and replaced by the new blob given.
+
+NOTE: In order to avoid leaving a bunch of orphaned blobs in the system, best practice is to delete existing blobs before adding new ones to media procedures
+
+WARNING: Ingesting records that trigger blob ingests remains flakier than ingesting other records. The speed at which records are ingested via this tool may be more likely to trigger throttling on the image downloading side. There are issues with ingesting blobs and finding/fixing failures even with CSV Importer, so there's still work to do...
+
+== Media-related config
+
+== Commands for blob ingest verification (general)
+=== `thor media:blob_data`
+Queries database to generate a CSV report of all media handling procedures in the system, and the  blobs attached to them.
+
+CSV is written to: `{base_directory}/blob_data.csv`
+
+This report columns:
+
+* Media Handling procedure identification number
+* `blobcsid`
+* Blob filename
+* Blob mimetype
+
+If a procedure does not have an attached blob, the last 3 columns are empty.
+
+=== `thor media:deriv_report`
+Makes API calls to report information on the derivatives generated for each `blobcsid` in the input file.
+
+If no input is specified, `thor media:blob_data` is invoked and its output (i.e. all blobs attached to media procedures) is used as the input.
+
+`thor media:deriv_report`
+
+Any CSV having `blobcsid` and `mimetype` values can be used as input.
+
+`thor media:deriv_report --blob_data ~/data/my_custom_blob_data.csv`
+
+==== Report description
+All columns from input data are included.
+
+===== Rows for blobs with mimetypes for which derivatives are not generated
+
+Since CS only generates derivatives for images, any rows with non-image mimetypes are marked:
+
+* `derivable?` = `n`
+* `check_success?` = `n/a`
+
+No API call is made for these. The remaining columns are blank
+
+Derivative generation is supported only for some image formats. If mimetype indicates a non-supported filetype, the row is treated as above.
+
+===== Rows for blobs with mimetypes for which derivatives should be generated
+
+For rows with mimetypes where derivatives are generated, `derivable?` = `y` and an API call on the `blobcsid` value is made to get derivative info.
+
+If the API returns a successful response, `check_success?` = `y`. Otherwise, `check_success?` = `n` and error info/message is written to `error_msgs` column.
+
+When the API call was successful, the `deriv_ct` = the number of derivatives present for the blob.
+
+There are columns for each expected derivative type. If that type is present, that column = `y`. Otherwise the value is blank.
+
+== Notes on working with media/blobs
+
+There is an unresolved issue in the deprecated CSPACE JIRA project about characters in file ingest paths causing ingest failure:
+https://collectionspace.atlassian.net/browse/CSPACE-6810[CSPACE-6810]
+
+=== Deleting/replacing blobs
+
+You can directly delete blobs by CSID:
+
+`client.delete('/blobs/{csid}')`
+
+That's a hard delete, but it breaks the Media Handling record to which the blob is attached in two ways:
+
+* The File Info section shows no info, but also doesn't let you upload a new file
+* The Media header in the right sidebar shows 1
+
+This is ok if you are immediately coming back and reingesting another blob (as seen in https://github.com/collectionspace/collectionspace-client/blob/34fc9e6a258dd41898570c7591c158228e1d4098/lib/collectionspace/client/helpers.rb#L124-L142[collectionspace-client's `reset-media-blob` helper method)
+
+*Preferred*:
+
+Delete the affected media handling record:
+
+`client.delete('/media/{csid}')`
+
+This gets rid of both the media handling procedure and the blob cleanly. Then you can reload the media handling procedure.
+
+*Avoid orphan blobs*
+You _*can*_ reload an existing media handling procedure with a mediaFileUri value. In the UI and in the procedure's `blobcsid` value, you will see the new blob. BUT the old blob is not deleted.

--- a/doc/media.adoc
+++ b/doc/media.adoc
@@ -38,6 +38,7 @@ CSV is written to: `{base_directory}/blob_data.csv`
 This report columns:
 
 * Media Handling procedure identification number
+* `mhcsid` - CSID of the Media Handling procedure
 * `blobcsid`
 * Blob filename
 * Blob mimetype

--- a/doc/media.adoc
+++ b/doc/media.adoc
@@ -25,6 +25,10 @@ WARNING: Ingesting records that trigger blob ingests remains flakier than ingest
 
 == Media-related config
 
+=== `media_with_blob_upload_delay`
+
+This is documented in comments in `sample_client_config.yml`
+
 == Commands for blob ingest verification (general)
 === `thor media:blob_data`
 Queries database to generate a CSV report of all media handling procedures in the system, and the  blobs attached to them.

--- a/doc/workflows.adoc
+++ b/doc/workflows.adoc
@@ -104,14 +104,14 @@ If autocaching is enabled, the first step of the mapping process involves:
 
 * determining the refname and csid cache dependencies for the batch, based on record type and fields populated
 * querying the database for that data
-* re-caching the query results 
+* re-caching the query results
 
 ==== For objects, procedures, and authorities
 The JSON record mapper for each record type specifies vocabulary or authority term sources and transformations for each possible field.
 
 These fields will need to be populated with the refnames of existing terms, so the refname cache needs to be populated.
 
-To get the record status of (new or existing) of each record being mapped, we need the csids for the record type of the batch. 
+To get the record status of (new or existing) of each record being mapped, we need the csids for the record type of the batch.
 
 The only csid cache dependency will be the record type of the batch.
 
@@ -216,7 +216,7 @@ If any records failed to map because refnames were not found for authority or vo
 
 This CSV can be sorted by expected term source vocabulary, and the contents used to create source CSVs for necessary authority term ingests.
 
-NOTE: This list includes terms from vocabularies/dynamic term lists,footnote:[Distinct from terms from a specific authority vocabulary, such as person-ulan] but it is not yet possible to batch ingest vocabulary terms. 
+NOTE: This list includes terms from vocabularies/dynamic term lists,footnote:[Distinct from terms from a specific authority vocabulary, such as person-ulan] but it is not yet possible to batch ingest vocabulary terms.
 
 ==== `batches.csv`
 Populates the following columns:
@@ -253,7 +253,7 @@ For testing/standalone work: `thor upload:dir DIRNAME`
 
 If running the testing/standalone command, DIRNAME should be the name of a directory in whatever you have as `batch_dir` in your client config. This directory should contain .xml files and a `mapper_report.csv`.
 
-This is more of an IO-bound, rather than CPU-bound process, so it runs in threads. 
+This is more of an IO-bound, rather than CPU-bound process, so it runs in threads.
 
 It reads in `mapper_report.csv`, ignores any rows where mapping failed, and writes the contents of each `cmt_output_file` to the S3 bucket with the object key in `cmt_s3_key`.
 
@@ -294,12 +294,10 @@ Also prints this info to the screen at the end of the batch run.
 
 ==== Media Handling
 
-You can transfer media and import files by including a URI in `mediaFileURI` column of your CSV. This works for:
+Media Handling procedures without blobs are ingested normally.
 
-* new media records created
-* existing media records updated -- If existing media records have blobs attached they will be unattached and replaced by the new blob given.
+Media Handling procedures with blobs can be ingested, but there are some special config settings and commands to support flakiness around batch ingest of files and derivative generation. These are documented on a https://github.com/lyrasis/collectionspace_migration_tools/blob/main/doc/media.adoc[separate page].
 
-WARNING: Ingesting records that trigger blob ingests remains flakier than ingesting other records. The speed at which records are ingested via this tool may be more likely to trigger throttling on the image downloading side. There are issues with ingesting blobs and finding/fixing failures even with CSV Importer, so there's still work to do...
 
 ==== Upload step followups
 I have not run into enough problems on this step while developing/testing to see anything that can be systematized.
@@ -310,7 +308,7 @@ The number of reported ok uploads plus the number of reported upload errors shou
 
 === Verify ingest completion and status
 
-NOTE: There is no standalone/test command for this, since the entire functionality of this step depends on the context of a batch. 
+NOTE: There is no standalone/test command for this, since the entire functionality of this step depends on the context of a batch.
 
 In this step we do our best to determine:
 
@@ -320,7 +318,7 @@ In this step we do our best to determine:
 
 This step is a little tricky because the S3/Lambda side of things has no concept of a batch at all. We fake that by prefixing the object keys with the batch id.
 
-Also, the AWS side of things generates logs but does not report back anything coherent about failures. At last check, the log message containing the actual reason for an ingest failure did not also contain the S3 object key or anything else we can easily use to connect an error message to information on our end.  
+Also, the AWS side of things generates logs but does not report back anything coherent about failures. At last check, the log message containing the actual reason for an ingest failure did not also contain the S3 object key or anything else we can easily use to connect an error message to information on our end.
 
 Expectations/assumptions:
 

--- a/doc/workflows.adoc
+++ b/doc/workflows.adoc
@@ -385,6 +385,12 @@ Clearly you'll need to check out any reported upload errors.
 
 The number of reported ok uploads plus the number of reported upload errors should equal the number of successfully mapped records. There is https://github.com/lyrasis/collectionspace_migration_tools/issues/2[an issue] to add verification of this to the post-upload reporting.
 
+==== `thor decode:objects` command
+
+This decodes the S3 object keys of all objects in the S3 bucket and writes them to a CSV.
+
+This can be a shortcut for finding out the human-readable ids (i.e. objectnumber or acquisitionreferencenumber) of records that failed to ingest.
+
 ==== Invalid data in a structured date group
 
 The following in XML payload caused ingest error with 400 code:

--- a/lib/collectionspace_migration_tools/batch/batch.rb
+++ b/lib/collectionspace_migration_tools/batch/batch.rb
@@ -11,7 +11,7 @@ module CollectionspaceMigrationTools
       include CMT::Batch::Mappable
       include CMT::Batch::Uploadable
       include CMT::Batch::Ingestable
-      
+
       def initialize(csv, id)
         @csv = csv
         @id = id
@@ -29,7 +29,7 @@ module CollectionspaceMigrationTools
 
       def is_done?
         return true if done? == 'y'
-        
+
         missing_vals = CMT::Batch::Csv::Headers.populated_if_done_headers
           .map{ |field| send(field.to_sym) }
           .select{ |val| val.nil? || val.empty? }
@@ -42,7 +42,7 @@ module CollectionspaceMigrationTools
 
         Success(val)
       end
-      
+
       def mark_done
         data['done?'] = 'y'
         rewrite
@@ -99,14 +99,14 @@ module CollectionspaceMigrationTools
         #{datastr}>
         OBJ
       end
-      
+
       private
 
       attr_reader :csv, :id, :data, :dirpath
 
       def delete_batch_dir
         return Success() unless dirpath
-        
+
         FileUtils.rm_rf(dirpath) if Dir.exists?(dirpath)
       rescue StandardError => err
         msg = "#{err.message} IN #{err.backtrace[0]}"

--- a/lib/collectionspace_migration_tools/batch/upload_runner.rb
+++ b/lib/collectionspace_migration_tools/batch/upload_runner.rb
@@ -18,6 +18,7 @@ module CollectionspaceMigrationTools
 
       def call
         batch = yield CMT::Batch.find(batch_id)
+
         mapped = batch.mapped?
         if mapped.nil? || mapped.empty?
           return Failure(
@@ -32,9 +33,12 @@ module CollectionspaceMigrationTools
 
         batch_dir = yield CMT::Batch.dir(batch_id)
 
+
         puts "\n\nUPLOADING"
-        uploader = yield CMT::S3::UploaderPreparer.new(file_dir: batch_dir)
-          .call
+        uploader = yield CMT::S3::UploaderPreparer.new(
+          file_dir: batch_dir,
+          rectype: batch.mappable_rectype
+        ).call
         _uploaded = yield uploader.call
         report = yield CMT::Batch::PostUploadReporter.new(
           batch: batch,

--- a/lib/collectionspace_migration_tools/batch/upload_runner.rb
+++ b/lib/collectionspace_migration_tools/batch/upload_runner.rb
@@ -17,26 +17,33 @@ module CollectionspaceMigrationTools
       end
 
       def call
-        batch = yield(CMT::Batch.find(batch_id))
+        batch = yield CMT::Batch.find(batch_id)
         mapped = batch.mapped?
         if mapped.nil? || mapped.empty?
-          return Failure("Batch #{batch_id} has not been mapped. You must map before uploading")
+          return Failure(
+            "Batch #{batch_id} is not mapped. You must map before uploading"
+          )
         end
-        
+
         uploadable = batch.map_oks
         if uploadable.nil? || uploadable.empty? || uploadable == '0'
           return Failure("No uploadable records for batch: #{batch_id}")
         end
-        
-        batch_dir = yield(CMT::Batch.dir(batch_id))
-       
+
+        batch_dir = yield CMT::Batch.dir(batch_id)
+
         puts "\n\nUPLOADING"
-        uploader = yield(CMT::S3::UploaderPreparer.new(file_dir: batch_dir).call)
-        _uploaded = yield(uploader.call)
-        report = yield(CMT::Batch::PostUploadReporter.new(batch: batch, dir: batch_dir).call)
+        uploader = yield CMT::S3::UploaderPreparer.new(file_dir: batch_dir)
+          .call
+        _uploaded = yield uploader.call
+        report = yield CMT::Batch::PostUploadReporter.new(
+          batch: batch,
+          dir: batch_dir
+        ).call
+
         Success(report)
       end
-      
+
       private
 
       attr_reader :batch_id

--- a/lib/collectionspace_migration_tools/csv/batch_reporter.rb
+++ b/lib/collectionspace_migration_tools/csv/batch_reporter.rb
@@ -11,7 +11,9 @@ module CollectionspaceMigrationTools
 
       def initialize(output_dir:, fields:, term_reporter:)
         @path = "#{output_dir}/mapper_report.csv"
-        @fields = [fields, 'CMT_rec_status', 'CMT_outcome', 'CMT_output_file', 'CMT_S3_key', 'CMT_warnings', 'CMT_errors'].flatten
+        @fields = [fields, 'CMT_rec_status', 'CMT_outcome', 'CMT_output_file',
+                   'CMT_S3_key', 'CMT_warnings', 'CMT_errors']
+                     .flatten
         @term_reporter = term_reporter
         CSV.open(path, 'wb'){ |csv| csv << @fields }
       end
@@ -39,9 +41,9 @@ module CollectionspaceMigrationTools
       def to_monad
         Success(self)
       end
-      
+
       private
-      
+
       attr_reader :path, :fields, :term_reporter
 
       def add_errors(result, data, source)
@@ -78,11 +80,11 @@ module CollectionspaceMigrationTools
       def compile_processor_errors(result)
         result.errors.map{ |err| "#{err[:category]}: #{err[:message]}" }.join("; ")
       end
-      
+
       def compile_warnings(result)
         warnings = result.warnings
         return nil if warnings.empty?
-        
+
         result.warnings.map{ |warning| warning[:message] }.join("; ")
       end
 

--- a/lib/collectionspace_migration_tools/database/query.rb
+++ b/lib/collectionspace_migration_tools/database/query.rb
@@ -6,6 +6,21 @@ module CollectionspaceMigrationTools
 
       module_function
 
+      def blobs_on_media
+        %{ with blobs as (
+          select hier.name as blobcsid, bc.name as filename, bc.mimetype
+          from blobs_common bc
+          inner join misc ON misc.id = bc.id
+            AND misc.lifecyclestate != 'deleted'
+          inner join hierarchy hier on hier.id = bc.id
+        )
+        select med.identificationnumber, blobs.*
+          from media_common med
+        inner join misc ON misc.id = med.id
+          AND misc.lifecyclestate != 'deleted'
+        left outer join blobs on med.blobcsid = blobs.blobcsid }
+      end
+
       def refnames
         %{ SELECT CC.REFNAME FROM PUBLIC.COLLECTIONSPACE_CORE CC
            INNER JOIN MISC ON CC.ID = MISC.ID

--- a/lib/collectionspace_migration_tools/database/query.rb
+++ b/lib/collectionspace_migration_tools/database/query.rb
@@ -14,9 +14,10 @@ module CollectionspaceMigrationTools
             AND misc.lifecyclestate != 'deleted'
           inner join hierarchy hier on hier.id = bc.id
         )
-        select med.identificationnumber, blobs.*
-          from media_common med
-        inner join misc ON misc.id = med.id
+        select med.identificationnumber, hier.name as mhcsid, blobs.*
+        from media_common med
+        inner join hierarchy hier on med.id = hier.id
+        inner join misc ON misc.id = med.id AND misc.lifecyclestate != 'deleted'
           AND misc.lifecyclestate != 'deleted'
         left outer join blobs on med.blobcsid = blobs.blobcsid }
       end

--- a/lib/collectionspace_migration_tools/database/query.rb
+++ b/lib/collectionspace_migration_tools/database/query.rb
@@ -8,7 +8,8 @@ module CollectionspaceMigrationTools
 
       def refnames
         %{ SELECT CC.REFNAME FROM PUBLIC.COLLECTIONSPACE_CORE CC
-           INNER JOIN MISC ON CC.ID = MISC.ID AND MISC.LIFECYCLESTATE != 'deleted'
+           INNER JOIN MISC ON CC.ID = MISC.ID
+             AND MISC.LIFECYCLESTATE != 'deleted'
            WHERE CC.URI not like '/contacts%'
            AND CC.URI not like '/relations%'
            AND CC.URI not like '/blobs%'

--- a/lib/collectionspace_migration_tools/decode.rb
+++ b/lib/collectionspace_migration_tools/decode.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'base64'
+
+module CollectionspaceMigrationTools
+  module Decode
+    ::CMT::Decode = CollectionspaceMigrationTools::Decode
+    extend Dry::Monads[:result, :do]
+
+    module_function
+
+    def key(key)
+      result = Base64.urlsafe_decode64(key)
+    rescue StandardError => err
+      msg = "#{err.message} IN #{err.backtrace[0]}"
+      Failure(CMT::Failure.new(
+        context: "#{self.name}.#{__callee__}(#{key})", message: msg
+      ))
+    else
+      Success(result)
+    end
+
+    def segments(key)
+      delim = CMT.config.client.s3_delimiter
+      decoded = yield key(key)
+
+      Success(decoded.split(delim))
+    end
+
+    def to_h(key)
+      parts = yield segments(key)
+
+      Success({
+        key: key,
+        batch: parts[0],
+        path: parts[1],
+        id: parts[2],
+        action: parts[3]
+      })
+    end
+  end
+end

--- a/lib/collectionspace_migration_tools/failure.rb
+++ b/lib/collectionspace_migration_tools/failure.rb
@@ -9,6 +9,10 @@ module CollectionspaceMigrationTools
       @message = message
     end
 
+    def for_csv
+      "ERROR in #{context}: #{message}"
+    end
+
     def to_s
       <<~MSG
          ERROR in #{context}

--- a/lib/collectionspace_migration_tools/media.rb
+++ b/lib/collectionspace_migration_tools/media.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+module CollectionspaceMigrationTools
+  module Media
+    ::CMT::Media = CollectionspaceMigrationTools::Media
+    extend Dry::Monads[:result, :do]
+
+    module_function
+
+    def blob_data
+      query = CMT::Database::Query.blobs_on_media
+      puts "\nQuerying for media blob details..."
+      rows = yield(CMT::Database::ExecuteQuery.call(query))
+      CMT.connection.close if CMT.connection
+      CMT.tunnel.close if CMT.tunnel
+
+      Success(rows)
+    end
+
+    def blob_data_path
+      result = File.join(
+        CMT.config.client.base_dir,
+        'blob_data.csv'
+      )
+    rescue StandardError => err
+      msg = "#{err.message} IN #{err.backtrace[0]}"
+      Failure(CMT::Failure.new(
+        context: "#{self.name}.#{__callee__}(#{key})", message: msg
+      ))
+    else
+      Success(result)
+    end
+
+    def blob_data_report
+      rows = yield blob_data
+      path = yield blob_data_path
+      _written = yield write_blob_data_report(rows, path)
+
+      Success()
+    end
+
+    def write_blob_data_report(rows, path)
+      headers = rows[0].keys
+      CSV.open(path, 'w') do |csv|
+        csv << headers
+        rows.each{ |row| csv << row.values }
+      end
+    rescue StandardError => err
+      msg = "#{err.message} IN #{err.backtrace[0]}"
+      Failure(CMT::Failure.new(
+        context: "#{self.name}.#{__callee__}(#{key})", message: msg
+      ))
+    else
+      puts "Wrote blob data report to #{path}..."
+      Success()
+    end
+  end
+end

--- a/lib/collectionspace_migration_tools/media/deriv_check_processor.rb
+++ b/lib/collectionspace_migration_tools/media/deriv_check_processor.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'parallel'
+
+module CollectionspaceMigrationTools
+  module Media
+    # Handles parallel processing of derivative checks
+    class DerivCheckProcessor
+      include Dry::Monads[:result]
+
+      class << self
+        def call(...)
+          self.new(...).call
+        end
+      end
+
+      # @param checker [CMT::Media::DerivChecker]
+      # @param rows [Array<CSV::Row>] CSV rows must have `blobcsid` column
+      def initialize(checker:, rows:)
+        @checker = checker
+        size = CMT.config.system.csv_chunk_size
+        @chunks = rows.each_slice(size).to_a
+      end
+
+      def call
+        puts 'Making API calls to check derivatives. This will take a long '\
+          'time...'
+        start_time = Time.now
+        result = Parallel.map(chunks,
+                     in_threads: CMT.config.system.max_threads) do |chunk|
+          worker(chunk)
+        end
+        elap = Time.now - start_time
+        puts "Threaded derivative checking time: #{elap}"
+      rescue StandardError => err
+        msg = "#{err.message} IN #{err.backtrace[0]}"
+        Failure(
+          CMT::Failure.new(
+            context: "#{self.class.name}.#{__callee__}",
+            message: msg
+          )
+        )
+      else
+        Success(result.flatten)
+      end
+
+      private
+
+      attr_reader :checker, :chunks
+
+      def worker(chunk)
+        chunk.map do |row|
+          CMT::Media::DerivableData.new(
+            blob: row,
+            deriv: checker.call(blobcsid: row['blobcsid'])
+          ).to_h
+        end
+      end
+
+      # @param rows [Array<CSV::Row>]
+      # @param checker [CMT::Media::DerivChecker]
+      def get_derivable(rows, checker)
+        result = rows.map do |row|
+          CMT::Media::DerivableData.new(
+            blob: row,
+            deriv: checker.call(blobcsid: row['blobcsid'])
+          ).to_h
+        end
+      rescue StandardError => err
+        msg = "#{err.message} IN #{err.backtrace[0]}"
+        Failure(CMT::Failure.new(
+          context: "#{self.class.name}.#{__callee__}", message: msg
+        ))
+      else
+        Success(result)
+      end
+    end
+  end
+end

--- a/lib/collectionspace_migration_tools/media/deriv_checker.rb
+++ b/lib/collectionspace_migration_tools/media/deriv_checker.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module CollectionspaceMigrationTools
+  module Media
+    # Uses client to make and extract data from
+    #   `/blobs/{csid}/derivatives` API calls
+    class DerivChecker
+      include Dry::Monads[:result]
+      include Dry::Monads::Do.for(:call)
+
+      class << self
+        def call(client:, obj: CMT::Media::DerivData, blobcsid:)
+          self.new(client: client, obj: obj).call(blobcsid: blobcsid)
+        end
+      end
+
+      def initialize(client:, obj: CMT::Media::DerivData)
+        @client = client
+        @obj = obj
+      end
+
+      def call(blobcsid:)
+        path = "/blobs/#{blobcsid}/derivatives"
+        response = yield get_client_response(path)
+
+        Success(obj.new(blobcsid: blobcsid, response: response))
+      end
+
+      def to_monad
+        Success(self)
+      end
+
+      private
+
+      attr_reader :client, :obj
+
+      def get_client_response(path)
+        result = client.get(path)
+      rescue StandardError => err
+        msg = "#{err.message} IN #{err.backtrace[0]}"
+        Failure(CMT::Failure.new(
+          context: "#{self.class.name}.#{__callee__}", message: msg
+        ))
+      else
+        return Success(result.parsed) if result.result.success?
+
+        Failure(
+          CMT::Failure.new(
+            context: result.class.name,
+            message: "#{result.status_code}: #{result.parsed}"
+          )
+        )
+      end
+    end
+  end
+end

--- a/lib/collectionspace_migration_tools/media/deriv_data.rb
+++ b/lib/collectionspace_migration_tools/media/deriv_data.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module CollectionspaceMigrationTools
+  module Media
+    # Value object representing derivative data
+    class DerivData
+      DERIV_TYPES = %w[small medium thumbnail originaljpeg fullhd].freeze
+      DERIV_TYPES.each do |type|
+        define_method("#{type}?"){ derivs.any?(type) }
+      end
+
+      attr_reader :deriv_ct, :derivs
+
+      def initialize(blobcsid:, response:)
+        @blobcsid = blobcsid
+        @response = response['abstract_common_list']
+        @deriv_ct = get_count
+        @derivs = get_derivs
+      end
+
+      def to_h
+        DERIV_TYPES.map{ |type| [type, translate_type(type)] }
+          .to_h
+          .merge({'deriv_ct'=>deriv_ct})
+      end
+
+      private
+
+      attr_reader :blobcsid, :response
+
+      # @param item [Hash] element of response['list_item']
+      def deriv_title(item)
+        item['uri'].delete_prefix("/blobs/#{blobcsid}/derivatives/")
+          .delete_suffix("/content")
+          .downcase
+      end
+
+      def get_count
+        items = response['list_item']
+        return 0 unless items
+
+        items.length
+      end
+
+      def get_derivs
+        items = response['list_item']
+        return [] unless items
+
+        items.map{ |item| deriv_title(item) }
+      end
+
+      def translate_type(type)
+        send(:"#{type}?") ? 'y' : nil
+      end
+    end
+  end
+end

--- a/lib/collectionspace_migration_tools/media/deriv_reporter.rb
+++ b/lib/collectionspace_migration_tools/media/deriv_reporter.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+module CollectionspaceMigrationTools
+  module Media
+    # Use API calls to generate detailed report of derivatives present
+    #   for given blobs
+    class DerivReporter
+      include Dry::Monads[:result]
+      include Dry::Monads::Do.for(:call)
+
+
+      class << self
+        def call(...)
+          self.new(...).call
+        end
+      end
+
+      # @param csv_path [nil, String] path to CSV of blob_data
+      def initialize(csv_path: nil)
+        @csv_path = csv_path
+        # from imageTypes static variable used in `isImageMedia` function in:
+        #   https://github.com/collectionspace/services/blob/master/services/common/src/main/java/org/collectionspace/services/common/imaging/nuxeo/NuxeoBlobUtils.java
+        @derivable_image_types = %w[jpeg bmp gif png tiff octet-stream]
+      end
+
+      def call
+        puts "Setting up to produce deriv report..."
+
+        client = yield CMT::Client.call
+        if csv_path
+          path = File.expand_path(csv_path)
+        else
+          _blob_data = yield CMT::Media.blob_data_report
+          path = yield CMT::Media.blob_data_path
+        end
+        row_getter = yield CMT::Csv::FirstRowGetter.new(path)
+        csvchecker = yield CMT::Csv::FileChecker.call(path, row_getter)
+        blob_row = csvchecker[1]
+
+        checker = yield CMT::Media::DerivChecker.new(client: client)
+
+        headers = [
+          blob_row.headers,
+          'derivable?', 'check_success?',
+          'deriv_ct',
+          CMT::Media::DerivData::DERIV_TYPES,
+          'error_msgs'
+          ].flatten
+        grouped_rows = yield group_rows(path)
+        derivable = yield CMT::Media::DerivCheckProcessor.call(
+          checker: checker,
+          rows: grouped_rows[:derivable]
+        )
+        underivable = yield get_underivable(grouped_rows[:underivable])
+
+        _written = yield write_report(
+          headers: headers,
+          rows: [derivable, underivable].flatten
+        )
+
+        Success()
+      end
+
+      private
+
+      attr_reader :csv_path, :derivable_image_types
+
+      def write_report(headers:, rows:)
+        outpath = File.join(
+          CMT.config.client.base_dir,
+          'blob_derivative_report.csv'
+        )
+        CSV.open(outpath, 'w') do |csv|
+          csv << headers
+          rows.each{ |row| csv << row.values_at(*headers) }
+        end
+      rescue StandardError => err
+        msg = "#{err.message} IN #{err.backtrace[0]}"
+        Failure(CMT::Failure.new(
+          context: "#{self.class.name}.#{__callee__}", message: msg
+        ))
+      else
+        puts "Wrote derivatives report to #{outpath}..."
+        Success()
+      end
+
+      # @param rows [Array<CSV::Row>]
+      # @param checker [CMT::Media::DerivChecker]
+      def get_derivable(rows, checker)
+        start_time = Time.now
+        result = rows.map do |row|
+          CMT::Media::DerivableData.new(
+            blob: row,
+            deriv: checker.call(blobcsid: row['blobcsid'])
+          ).to_h
+        end
+      rescue StandardError => err
+        msg = "#{err.message} IN #{err.backtrace[0]}"
+        Failure(CMT::Failure.new(
+          context: "#{self.class.name}.#{__callee__}", message: msg
+        ))
+      else
+        elap = Time.now - start_time
+        puts "Derivative checking time: #{elap}"
+
+        Success(result)
+      end
+
+      def get_underivable(rows)
+        result = rows.map do |row|
+          row.to_h
+            .merge({
+              'derivable?'=>'n',
+              'check_success?'=> 'n/a'
+            })
+        end
+      rescue StandardError => err
+        msg = "#{err.message} IN #{err.backtrace[0]}"
+        Failure(CMT::Failure.new(
+          context: "#{self.class.name}.#{__callee__}", message: msg
+        ))
+      else
+        Success(result)
+      end
+
+      def group_rows(path)
+        derivable = []
+        underivable = []
+        CSV.foreach(path, headers: true) do |row|
+          derivable?(row['mimetype']) ? derivable << row : underivable << row
+        end
+        result = {derivable: derivable, underivable: underivable}
+      rescue StandardError => err
+        msg = "#{err.message} IN #{err.backtrace[0]}"
+        Failure(CMT::Failure.new(
+          context: "#{self.class.name}.#{__callee__}", message: msg
+        ))
+      else
+        Success(result)
+      end
+
+      def image?(mimetype)
+        return false unless mimetype
+
+        mimetype.start_with?('image/')
+      end
+
+      def derivable?(mimetype)
+        return false unless mimetype
+        return false unless image?(mimetype)
+
+        derivable_image_types.any?(
+          mimetype.split('/').last
+        )
+      end
+    end
+  end
+end

--- a/lib/collectionspace_migration_tools/media/derivable_data.rb
+++ b/lib/collectionspace_migration_tools/media/derivable_data.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module CollectionspaceMigrationTools
+  module Media
+    class DerivableData
+      # @param blob [CSV::Row]
+      # @param deriv [Dry::Monad::Result(CMT::Media::DerivData)]
+      def initialize(blob:, deriv:)
+        @blob = blob
+        @deriv = deriv
+      end
+
+      def to_h
+        deriv.either(
+          ->success{ success_to_h(success) },
+          ->failure{ failure_to_h(failure) }
+        )
+      end
+
+      def to_monad
+        deriv
+      end
+
+      private
+
+      attr_reader :blob, :deriv
+
+      # @param data [CMT::Failure]
+      def failure_to_h(data)
+        blob.to_h
+          .merge({
+            'derivable?'=>'y',
+            'check_success?'=>'n',
+            'error_msgs'=>data.for_csv
+          })
+      end
+
+      # @param data [CMT::Media::DerivData]
+      def success_to_h(data)
+        blob.to_h
+          .merge(data.to_h)
+          .merge({
+            'derivable?'=>'y',
+            'check_success?'=>'y'
+          })
+      end
+    end
+  end
+end

--- a/lib/collectionspace_migration_tools/s3/batch_uploader.rb
+++ b/lib/collectionspace_migration_tools/s3/batch_uploader.rb
@@ -24,20 +24,20 @@ module CollectionspaceMigrationTools
         elap = Time.now - start_time
         puts "Upload time: #{elap}"
         puts "INFO: Results written to: #{reporter.path}"
-        
+
         Success()
       end
 
       def to_monad
         Success(self)
       end
-      
+
       def to_s
         "<##{self.class}:#{self.object_id.to_s(8)} #{csv_path}>"
       end
 
       private
-      
+
       attr_reader :csv_path, :uploader, :reporter
 
       def chunks
@@ -48,15 +48,22 @@ module CollectionspaceMigrationTools
             strings_as_keys: true
           })
       end
-      
+
       def process
         puts "Uploading CS XML to S3..."
-        Parallel.map(chunks, in_threads: CMT.config.system.max_threads) do |chunk|
+        Parallel.map(
+          chunks, in_threads: CMT.config.system.max_threads
+        ) do |chunk|
           worker(chunk)
         end
       rescue StandardError => err
         msg = "#{err.message} IN #{err.backtrace[0]}"
-        Failure(CMT::Failure.new(context: "#{self.class.name}.#{__callee__}", message: msg))
+        Failure(
+          CMT::Failure.new(
+            context: "#{self.class.name}.#{__callee__}",
+            message: msg
+          )
+        )
       else
         Success()
       end

--- a/lib/collectionspace_migration_tools/s3/obj_key_decoder.rb
+++ b/lib/collectionspace_migration_tools/s3/obj_key_decoder.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+module CollectionspaceMigrationTools
+  module S3
+    class ObjKeyDecoder
+      include Dry::Monads[:result]
+      include Dry::Monads::Do.for(:call)
+
+      class << self
+        def call(...)
+          self.new.call(...)
+        end
+      end
+
+      def initialize()
+      end
+
+      # @param scope [:bucket, String] batch prefix can be passes as String
+      #   to limit to objects from a particular batch
+      # @param mode [:stdout, :csv]
+      def call(scope: :bucket, mode: :stdout)
+        if scope == :bucket
+          list = yield CMT::S3::Bucket.objects
+        elsif scope.is_a?(Array)
+          list = scope
+        else
+          list = yield CMT::S3::Bucket.batch_objects(scope)
+        end
+        decoded = list.map{ |key| CMT::Decode.to_h(key) }
+        successes = decoded.select{ |result| result.success? }
+          .map(&:value!)
+        failures = decoded.select{ |result| result.failure? }
+          .map(&:failure)
+
+        case mode
+        when :stdout
+          successes.each do |hash|
+            pp(hash)
+            puts ''
+          end
+          failures.each{ |f| puts f }
+        when :csv
+          path = yield write_csv(successes, failures)
+          puts "Wrote decoded to #{path}"
+        end
+
+        Success()
+      end
+
+      def to_monad
+        Success(self)
+      end
+
+      private
+
+      def write_csv(successes, failures)
+        headers = successes.first.keys
+        now = Time.now.strftime("%F_%H_%M")
+        path = File.join(
+          CMT.config.client.base_dir,
+          "s3_objs_decoded_#{now}.csv"
+        )
+        CSV.open(path, 'w') do |csv|
+          csv << headers
+          successes.each{ |success| csv << success.values }
+          failures.each do |failure|
+            csv << [
+              failure.context.match(/\((.*)\)/)[1],
+              'DECODE ERROR',
+              failure.message
+              ]
+          end
+        end
+      rescue StandardError => err
+        msg = "#{err.message} IN #{err.backtrace[0]}"
+        Failure(
+          CMT::Failure.new(
+            context: "#{self.class.name}.#{__callee__}", message: msg
+          )
+        )
+      else
+        Success(path)
+      end
+    end
+  end
+end

--- a/lib/collectionspace_migration_tools/s3/object_key_creator.rb
+++ b/lib/collectionspace_migration_tools/s3/object_key_creator.rb
@@ -23,7 +23,12 @@ module CollectionspaceMigrationTools
         final_path = svc_path == '/media' ? media_path(response, base_path) : base_path
         result = Base64.urlsafe_encode64([batch, final_path, id, action].join(separator))
       rescue
-        Failure(CMT::Failure.new(context: "#{self.class.name}.#{__callee__}", message: err))
+        Failure(
+          CMT::Failure.new(
+            context: "#{self.class.name}.#{__callee__}",
+            message: err
+          )
+        )
       else
         Success(result)
       end

--- a/lib/collectionspace_migration_tools/s3/object_key_creator.rb
+++ b/lib/collectionspace_migration_tools/s3/object_key_creator.rb
@@ -5,10 +5,13 @@ require 'dry/monads'
 
 module CollectionspaceMigrationTools
   module S3
+    ObjKey = Struct.new(:value, :warnings, keyword_init: true)
+
     # Base 64 hashed filenames for payloads to be transferred via S3
     class ObjectKeyCreator
+
       include Dry::Monads[:result]
-      
+
       # @param svc_path [String]
       def initialize(svc_path:, batch: nil)
         @svc_path = svc_path
@@ -20,8 +23,11 @@ module CollectionspaceMigrationTools
       def call(response, action)
         id = response.identifier
         base_path = action == 'CREATE' ? svc_path : "#{svc_path}/#{response.csid}"
-        final_path = svc_path == '/media' ? media_path(response, base_path) : base_path
-        result = Base64.urlsafe_encode64([batch, final_path, id, action].join(separator))
+        warnings = []
+        final_path = get_final_path(response, base_path, warnings)
+        result = Base64.urlsafe_encode64(
+          [batch, final_path, id, action].join(separator)
+        )
       rescue
         Failure(
           CMT::Failure.new(
@@ -30,24 +36,44 @@ module CollectionspaceMigrationTools
           )
         )
       else
-        Success(result)
+        Success(CMT::S3::ObjKey.new(value: result, warnings: warnings))
       end
 
       def to_monad
         Success(self)
       end
-      
+
       private
-      
+
       attr_reader :svc_path, :batch, :separator
 
-      def media_path(response, base_path)
+      def get_final_path(response, base_path, warnings)
+        return base_path unless svc_path == '/media'
+
         media_uri = response.orig_data['mediafileuri']
         return base_path if media_uri.blank?
 
-        "#{base_path}?blobUri=#{URI(media_uri)}"
+        media_path(media_uri, base_path, warnings)
+      end
+
+      def media_path(media_uri, base_path, warnings)
+        blob_uri = prepare_media_uri(media_uri, warnings)
+        if blob_uri
+          "#{base_path}?blobUri=#{blob_uri}"
+        else
+          base_path
+        end
+      end
+
+      def prepare_media_uri(media_uri, warnings)
+        result = URI(media_uri)
+      rescue URI::Error
+        warnings << 'media_uri cannot be encoded as valid ingest URI. File '\
+          'ingest may not work as expected'
+        media_uri
+      else
+        result.to_s
       end
     end
   end
 end
-

--- a/lib/collectionspace_migration_tools/s3/uploader_preparer.rb
+++ b/lib/collectionspace_migration_tools/s3/uploader_preparer.rb
@@ -12,13 +12,14 @@ module CollectionspaceMigrationTools
 
 
       class << self
-        def call(file_dir:)
-          self.new(file_dir: file_dir).call
+        def call(...)
+          self.new(...).call
         end
       end
 
-      def initialize(file_dir:)
+      def initialize(file_dir:, rectype:)
         @file_dir = "#{CMT.config.client.batch_dir}/#{file_dir}"
+        @rectype = rectype
       end
 
       def call
@@ -45,6 +46,7 @@ module CollectionspaceMigrationTools
 
         uploader = yield CMT::S3::ItemUploader.new(
           file_dir: file_dir,
+          rectype: rectype,
           client: client,
           reporter: reporter
         )
@@ -60,7 +62,7 @@ module CollectionspaceMigrationTools
 
       private
 
-      attr_reader :file_dir
+      attr_reader :file_dir, :rectype
     end
   end
 end

--- a/lib/collectionspace_migration_tools/version.rb
+++ b/lib/collectionspace_migration_tools/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CollectionspaceMigrationTools
-  VERSION = '0.1.2'
+  VERSION = '1.0.0'
 end

--- a/lib/collectionspace_migration_tools/xml/file_writer.rb
+++ b/lib/collectionspace_migration_tools/xml/file_writer.rb
@@ -10,7 +10,8 @@ module CollectionspaceMigrationTools
       include Dry::Monads[:result]
       include Dry::Monads::Do.for(:write)
 
-      def initialize(output_dir:, action_checker:, namer:, s3_key_creator:, reporter:)
+      def initialize(output_dir:, action_checker:, namer:, s3_key_creator:,
+                     reporter:)
         @output_dir = output_dir
         @action_checker = action_checker
         @namer = namer
@@ -29,28 +30,28 @@ module CollectionspaceMigrationTools
       def to_monad
         Success(self)
       end
-      
+
       private
 
       attr_reader :output_dir, :action_checker, :namer, :s3_key_creator, :reporter
 
       def check_existence(path, response)
         return Failure([:file_already_exists, response]) if File.exist?(path)
-        
+
         Success(response)
       end
 
       def write(response)
-        action = yield(action_checker.call(response))
-        file_name = yield(namer.call(response))
+        action = yield action_checker.call(response)
+        file_name = yield namer.call(response)
         path = "#{output_dir}/#{file_name}"
-        key = yield(s3_key_creator.call(response, action))
-        _checked = yield(check_existence(path, response))
-        _written = yield(write_file(path, response))
+        key = yield s3_key_creator.call(response, action)
+        _checked = yield check_existence(path, response)
+        _written = yield write_file(path, response)
 
         Success([response, file_name, key])
       end
-      
+
       def write_file(path, response)
         File.open(path, 'wb'){ |file| file << response.doc }
       rescue StandardError => err

--- a/lib/tasks/decode.thor
+++ b/lib/tasks/decode.thor
@@ -1,12 +1,21 @@
 # frozen_string_literal: true
 
-require 'base64'
 require 'thor'
 
 class Decode < Thor
+  desc 'objects', 'decodes object keys of all objects in S3 bucket'
+  def objects
+    CMT::S3::ObjKeyDecoder.call(mode: :csv).either(
+      ->(success){ exit(0) },
+      ->(failure){ puts failure.to_s; exit(1) }
+    )
+  end
+
   desc 'key KEY', 'decodes S3 object key; useful for debugging, etc.'
   def key(key)
-    puts Base64.urlsafe_decode64(key)
-    exit(0)
+    CMT::Decode.key(key).either(
+      ->(success){ puts success; exit(0) },
+      ->(failure){ puts failure.to_s; exit(1) }
+    )
   end
 end

--- a/lib/tasks/media.thor
+++ b/lib/tasks/media.thor
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'dry/monads'
+require 'thor'
+
+# tasks related to verifying media ingest
+class Media < Thor
+  include Dry::Monads[:result]
+
+  desc 'blob_data', 'writes CSV of media identificationnumber and '\
+                    'blob data, if present'
+  def blob_data
+    CMT::Media.blob_data_report.either(
+      ->(success){ exit(0) },
+      ->(failure){ puts failure.to_s; exit(1) }
+    )
+  end
+end

--- a/lib/tasks/media.thor
+++ b/lib/tasks/media.thor
@@ -15,4 +15,33 @@ class Media < Thor
       ->(failure){ puts failure.to_s; exit(1) }
     )
   end
+
+  desc 'deriv_report', 'writes CSV of derivative data'
+  long_desc <<-LONGDESC
+    Writes CSV report of derivatives for each blob attached to a media
+    handling procedure to `{base_dir}/blob_derivative_report.csv`
+
+    A `blob_data` path may be given. This should be a path to a CSV
+    containing `blobcsid` column having values for all blobs you
+    want to check derivatives for.
+
+    If no `blob_data` path is given, it runs the `thor media blob_data`
+    command and uses its output (i.e. ALL blobs attached to media in
+    the client instance) as its input.
+
+    This report relies on making a Services API call for every row, so
+    it takes a long time to run.
+  LONGDESC
+  option :blob_data,
+         type: :string,
+         banner: '/path/to/csv',
+         default: nil,
+         desc: 'Path to CSV with `blobcsid` column'
+  def deriv_report
+    CMT::Media::DerivReporter.call(csv_path: options[:blob_data])
+      .either(
+        ->(success){ exit(0) },
+        ->(failure){ puts failure.to_s; exit(1) }
+      )
+  end
 end

--- a/sample_client_config.yml
+++ b/sample_client_config.yml
@@ -3,7 +3,7 @@ client:
   username: admin@core.collectionspace.org
   password: Administrator
   page_size: 50
-  
+
   # The redis_db_number should be unique per config. This allows you to quickly clear the caches
   #  for one instance, without affecting the caches for other instances.
   # It's on you to ensure these numbers are unique across your configs. The app doesn't check this.
@@ -14,7 +14,7 @@ client:
   #   https://github.com/collectionspace/cspace-config-untangler/tree/main/data/mappers/community_profiles/
   # Refer to how the mappers (i.e. the mapping instructions for each record type) are organized there
   #   to find the proper values to put in here
-  
+
   # The release number for the instance, not the UI version or profile version
   # Replace the period with an underscore
   # This must be in quotes or 7_0 will get interpreted as 70 for some reason.
@@ -62,7 +62,7 @@ client:
   # path to valid JSON batch config for mapping CSV to CSXML
   # See https://github.com/collectionspace/collectionspace-mapper/blob/migration-tooling/doc/batch_configuration.adoc for options
   # This is optional and only needed if you need to tweak the mapper options.
-  # When using this application to create CSXML, the following batch config options are always sent to the mapper: 
+  # When using this application to create CSXML, the following batch config options are always sent to the mapper:
   #   - `status_check_method` = `cache`
   #   - `search_if_not_cached` = `false`
   # If you are NOT providing a custom config, comment out the following line.
@@ -86,7 +86,7 @@ client:
   #   The default value of this option is whatever you have set here.
   clear_cache_before_refresh: true
 
-  
+
   # column/field delimiter for input "CSV" files
   csv_delimiter: ","
 
@@ -97,6 +97,25 @@ client:
   s3_key: "value_of_bucket_key"
   s3_secret: "value_of_secret_for_bucket_key"
   s3_delimiter: "|"
+
+  # Controls pause/sleep time after uploading to S3 each media handling procedure record that has an
+  #   associated mediaFileURI. A pause is required with batches over a certain size to minimize
+  #   file storage and derivative generation failures.
+  # The value is in ms.
+  # The value here is based on CS Services code that waits 500 ms for derivatives to be
+  #   generated:
+  # https://cs.github.com/collectionspace/application/blob/5fb3d0ffc750bfdf19e57057ac3dc65827c01df0/cspi-services/src/main/java/org/collectionspace/chain/csp/persistence/services/BlobStorage.java#L95
+  # If you are still seeing blob file storage and derivative generation errors, increase this delay.
+  #   Uploads to S3 are threaded, so {system_config/max_threads} (default = 6) upload queues are happening
+  #   simultaneously. This may increase the time needed for derivative generation.
+  # The lambda process that grabs records out of the S3 bucket and makes the API calls
+  #   to ingest has some limit of how many records are processed at once, but this defaults to making calls
+  #   far faster than CS/Nuxeo can produce and store derivatives.
+  # If your mediaFileURI values point to downloadable files (the usual case), you may be able to decrease this
+  #   number, as there is delay during the download of each file for ingest. If the mediaFileURIs are to
+  #   local file system locations, this might need to be higher to build in the padding you *aren't* getting
+  #   since the files don't have to be downloaded.
+  media_with_blob_upload_delay: 500
 database:
   port: 5432
   db_password: dbpassword

--- a/spec/collectionspace_migration_tools/configuration_spec.rb
+++ b/spec/collectionspace_migration_tools/configuration_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe CollectionspaceMigrationTools::Configuration do
       expect(result.database.db_name).to eq('cs_cs')
       expect(result.client.auto_refresh_cache_before_mapping).to be false
       expect(result.client.clear_cache_before_refresh).to be false
+      expect(result.client.media_with_blob_upload_delay).to eq(0)
     end
   end
 
@@ -28,6 +29,7 @@ RSpec.describe CollectionspaceMigrationTools::Configuration do
       expect(result.client.batch_csv).to eq(File.join(result.client.base_dir, 'batch_tracker.csv'))
       expect(result.client.auto_refresh_cache_before_mapping).to be true
       expect(result.client.clear_cache_before_refresh).to be true
+      expect(result.client.media_with_blob_upload_delay).to eq(0.5)
     end
   end
 

--- a/spec/collectionspace_migration_tools/media/deriv_data_spec.rb
+++ b/spec/collectionspace_migration_tools/media/deriv_data_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require_relative '../../spec_helper'
+
+RSpec.describe CollectionspaceMigrationTools::Media::DerivData do
+  subject(:data){ described_class.new(blobcsid: 'foo', response: response) }
+
+  context 'with all derivs' do
+    let(:response) do
+      {'abstract_common_list'=>
+       {"pageNum"=>"0",
+        "pageSize"=>"0",
+        "itemsInPage"=>"0",
+        "totalItems"=>"0",
+        "fieldsReturned"=>"csid|uri|name|mimeType|encoding|length",
+        "list_item"=>
+          [{"uri"=>"/blobs/foo/derivatives/Small/content",
+            "name"=>"Small_2016.007.353.A.jpg",
+            "mimeType"=>"image/jpeg", "length"=>"212221"},
+           {"uri"=>"/blobs/foo/derivatives/Medium/content",
+            "name"=>"Medium_2016.007.353.A.jpg",
+            "mimeType"=>"image/jpeg", "length"=>"488692"},
+           {"uri"=>"/blobs/foo/derivatives/Thumbnail/content",
+            "name"=>"Thumbnail_2016.007.353.A.jpg",
+            "mimeType"=>"image/jpeg", "length"=>"68971"},
+           {"uri"=>"/blobs/foo/derivatives/OriginalJpeg/content",
+            "name"=>"OriginalJpeg_2016.007.353.A.jpg",
+            "mimeType"=>"image/jpeg", "length"=>"7449471"},
+           {"uri"=>"/blobs/foo/derivatives/FullHD/content",
+            "name"=>"FullHD_2016.007.353.A.jpg",
+            "mimeType"=>"image/jpeg", "length"=>"1541086"}]}}
+    end
+
+    it 'behaves as expected' do
+      expect(data.deriv_ct).to eq(5)
+      exderivs = %w[small medium thumbnail originaljpeg fullhd]
+      expect(data.derivs.sort).to eq(exderivs.sort)
+      expect(data.small?).to be true
+      expect(data.medium?).to be true
+      expect(data.thumbnail?).to be true
+      expect(data.originaljpeg?).to be true
+      expect(data.fullhd?).to be true
+    end
+  end
+
+  context 'when missing thumbnail' do
+    let(:response) do
+      {'abstract_common_list'=>
+       {"pageNum"=>"0",
+        "pageSize"=>"0",
+        "itemsInPage"=>"0",
+        "totalItems"=>"0",
+        "fieldsReturned"=>"csid|uri|name|mimeType|encoding|length",
+        "list_item"=>
+          [{"uri"=>"/blobs/foo/derivatives/Small/content",
+            "name"=>"Small_2016.007.353.A.jpg",
+            "mimeType"=>"image/jpeg", "length"=>"212221"},
+           {"uri"=>"/blobs/foo/derivatives/Medium/content",
+            "name"=>"Medium_2016.007.353.A.jpg",
+            "mimeType"=>"image/jpeg", "length"=>"488692"},
+           {"uri"=>"/blobs/foo/derivatives/OriginalJpeg/content",
+            "name"=>"OriginalJpeg_2016.007.353.A.jpg",
+            "mimeType"=>"image/jpeg", "length"=>"7449471"},
+           {"uri"=>"/blobs/foo/derivatives/FullHD/content",
+            "name"=>"FullHD_2016.007.353.A.jpg",
+            "mimeType"=>"image/jpeg", "length"=>"1541086"}]}}
+    end
+
+    it 'behaves as expected' do
+      expect(data.deriv_ct).to eq(4)
+      exderivs = %w[small medium originaljpeg fullhd]
+      expect(data.derivs.sort).to eq(exderivs.sort)
+      expect(data.small?).to be true
+      expect(data.medium?).to be true
+      expect(data.thumbnail?).to be false
+      expect(data.originaljpeg?).to be true
+      expect(data.fullhd?).to be true
+      derivhash = {
+        'small'=>'y',
+        'medium'=>'y',
+        'thumbnail'=>nil,
+        'originaljpeg'=>'y',
+        'fullhd'=>'y',
+        'deriv_ct'=>4
+      }
+      expect(data.to_h).to eq(derivhash)
+    end
+  end
+
+  context 'when no derivs' do
+    let(:response) do
+      {"abstract_common_list"=>{
+        "pageNum"=>"0",
+        "pageSize"=>"0",
+        "itemsInPage"=>"0",
+        "totalItems"=>"0",
+        "fieldsReturned"=>"csid|uri|name|mimeType|encoding|length"
+        }
+      }
+    end
+
+    it 'behaves as expected' do
+      expect(data.deriv_ct).to eq(0)
+      expect(data.derivs).to eq([])
+      expect(data.small?).to be false
+      expect(data.medium?).to be false
+      expect(data.thumbnail?).to be false
+      expect(data.originaljpeg?).to be false
+      expect(data.fullhd?).to be false
+    end
+  end
+end

--- a/spec/collectionspace_migration_tools/s3/object_key_creator_spec.rb
+++ b/spec/collectionspace_migration_tools/s3/object_key_creator_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe CollectionspaceMigrationTools::S3::ObjectKeyCreator do
       let(:response){ response_new }
       it 'returns Success containing expected name', :aggregate_failures do
         expect(result).to be_a(Dry::Monads::Success)
-        expect(result.value!).to eq(hashed)
+        expect(result.value!.value).to eq(hashed)
       end
 
       context 'with batch passed in' do
@@ -49,7 +49,52 @@ RSpec.describe CollectionspaceMigrationTools::S3::ObjectKeyCreator do
         let(:klass){ described_class.new(svc_path: svc_path, batch: batch) }
         it 'returns Success containing expected name', :aggregate_failures do
           expect(result).to be_a(Dry::Monads::Success)
-          expect(result.value!).to eq(hashed)
+          expect(result.value!.value).to eq(hashed)
+        end
+      end
+
+      context 'when media with blob' do
+        let(:svc_path){ '/media' }
+        let(:blob_uri){ 'http://place.io/img.jpg' }
+        let(:response) do
+          response = CollectionSpace::Mapper::Response.new(
+            {'identificationnumber' => rec_id,
+             'mediafileuri' => blob_uri}
+          )
+          response.merge_status_data({status: :new})
+          response.identifier = rec_id
+          response
+        end
+        let(:path){ "#{svc_path}?blobUri=#{blob_uri}" }
+        it 'returns Success containing expected name', :aggregate_failures do
+          expect(result).to be_a(Dry::Monads::Success)
+          expect(result.value!.value).to eq(hashed)
+        end
+
+        context 'with funky mediafileuri' do
+          let(:blob_uri){ 'http://place.io/img (4).jpg' }
+          it 'returns Success containing expected name', :aggregate_failures do
+            expect(result).to be_a(Dry::Monads::Success)
+            res = result.value!
+            expect(res.value).to eq(hashed)
+            expect(res.warnings.length).to eq(1)
+          end
+        end
+      end
+
+      context 'when media without blob' do
+        let(:svc_path){ '/media' }
+        let(:response) do
+          response = CollectionSpace::Mapper::Response.new(
+            {'identificationnumber' => rec_id}
+          )
+          response.merge_status_data({status: :new})
+          response.identifier = rec_id
+          response
+        end
+        it 'returns Success containing expected name', :aggregate_failures do
+          expect(result).to be_a(Dry::Monads::Success)
+          expect(result.value!.value).to eq(hashed)
         end
       end
     end
@@ -60,7 +105,7 @@ RSpec.describe CollectionspaceMigrationTools::S3::ObjectKeyCreator do
       let(:path) { "#{svc_path}/#{csid}" }
       it 'returns Success containing expected name', :aggregate_failures do
         expect(result).to be_a(Dry::Monads::Success)
-        expect(result.value!).to eq(hashed)
+        expect(result.value!.value).to eq(hashed)
       end
     end
 
@@ -70,7 +115,7 @@ RSpec.describe CollectionspaceMigrationTools::S3::ObjectKeyCreator do
       let(:path) { "#{svc_path}/#{csid}" }
       it 'returns Success containing expected name', :aggregate_failures do
         expect(result).to be_a(Dry::Monads::Success)
-        expect(result.value!).to eq(hashed)
+        expect(result.value!.value).to eq(hashed)
       end
     end
 

--- a/spec/collectionspace_migration_tools/s3/object_key_creator_spec.rb
+++ b/spec/collectionspace_migration_tools/s3/object_key_creator_spec.rb
@@ -2,9 +2,10 @@
 
 require_relative '../../spec_helper'
 
-# These tests assume the correct action has been assigned by `CMT::XML::ServicesApiActionChecker`
-#   That is, we don't check here for weird edge cases where the response for a DELETE does not
-#   contain a CSID, etc.
+# These tests assume the correct action has been assigned by
+#   `CMT::XML::ServicesApiActionChecker`. That is, we don't check here for
+#   weird edge cases where the response for a DELETE does not contain a CSID,
+#   etc.
 
 RSpec.describe CollectionspaceMigrationTools::S3::ObjectKeyCreator do
   let(:separator){ CMT.config.client.s3_delimiter }
@@ -14,8 +15,10 @@ RSpec.describe CollectionspaceMigrationTools::S3::ObjectKeyCreator do
   let(:path){ svc_path }
   let(:rec_id){ '123' }
   let(:csid){ '456' }
-  let(:hashed){ Base64.urlsafe_encode64([batch, path, rec_id, action].join(separator)) }
-  
+  let(:hashed) do
+    Base64.urlsafe_encode64([batch, path, rec_id, action].join(separator))
+  end
+
   let(:response_new) do
     response = CollectionSpace::Mapper::Response.new({'objectnumber' => rec_id})
     response.merge_status_data({status: :new})
@@ -28,8 +31,8 @@ RSpec.describe CollectionspaceMigrationTools::S3::ObjectKeyCreator do
     response.identifier = rec_id
     response
   end
-  
-  
+
+
   describe '#call' do
     let(:result){ klass.call(response, action) }
 

--- a/spec/support/fixtures/config_valid.yml
+++ b/spec/support/fixtures/config_valid.yml
@@ -3,7 +3,7 @@ client:
   username: admin@core.collectionspace.org
   password: Administrator
   page_size: 50
-  
+
   # The redis_db_number should be unique per config. This allows you to quickly clear the caches
   #  for one instance, without affecting the caches for other instances.
   # It's on you to ensure these numbers are unique across your configs. The app doesn't check this
@@ -13,7 +13,7 @@ client:
   #   https://github.com/collectionspace/cspace-config-untangler/tree/main/data/mappers/community_profiles/
   # Refer to how the mappers (i.e. the mapping instructions for each record type) are organized there
   #   to find the proper values to put in here
-  
+
   # The release number for the instance, not the UI version or profile version
   # Replace the period with an underscore
   # This must be in quotes or 7_0 will get interpreted as 70 for some reason.

--- a/spec/support/fixtures/config_valid_with_optional.yml
+++ b/spec/support/fixtures/config_valid_with_optional.yml
@@ -3,7 +3,7 @@ client:
   username: admin@core.collectionspace.org
   password: Administrator
   page_size: 50
-  
+
   # The redis_db_number should be unique per config. This allows you to quickly clear the caches
   #  for one instance, without affecting the caches for other instances.
   # It's on you to ensure these numbers are unique across your configs. The app doesn't check this
@@ -13,7 +13,7 @@ client:
   #   https://github.com/collectionspace/cspace-config-untangler/tree/main/data/mappers/community_profiles/
   # Refer to how the mappers (i.e. the mapping instructions for each record type) are organized there
   #   to find the proper values to put in here
-  
+
   # The release number for the instance, not the UI version or profile version
   # Replace the period with an underscore
   # This must be in quotes or 7_0 will get interpreted as 70 for some reason.
@@ -52,7 +52,7 @@ client:
 
   auto_refresh_cache_before_mapping: true
   clear_cache_before_refresh: true
-  
+
   # column/field delimiter for input "CSV" files
   csv_delimiter: ","
 
@@ -63,6 +63,7 @@ client:
   s3_key: "value_of_bucket_key"
   s3_secret: "value_of_secret_for_bucket_key"
   s3_delimiter: "|"
+  media_with_blob_upload_delay: 500
 database:
   port: 5432
   db_password: dbpassword


### PR DESCRIPTION
 - Write warning to mapper_report.csv if mediaFileURI does not convert to valid URI. This is a warning, not an error, since CS can successfully ingest from file paths that do not convert to valid URIs. 
 - Add `thor decode:objects` command. Streamlines the process of getting the human-readable record id values for objects left in S3 bucket (assumed to be ingest errors)
 - Add `thor media:blob_data` and `thor media:deriv_report` commands. See `doc/media.adoc` for details
 - Add optional `:media_with_blob_upload_delay` client config setting. When uploading to S3 bucket for ingest, will wait this long after each media record that has an associated `mediaFileURI` value.