### PR TITLE
Pass autodelete param to post-ingest check runner

### DIFF
--- a/lib/collectionspace_migration_tools/batch/ingest_check_runner.rb
+++ b/lib/collectionspace_migration_tools/batch/ingest_check_runner.rb
@@ -41,7 +41,7 @@ module CollectionspaceMigrationTools
         end
 
         _post = yield CMT::Batch::PostIngestCheckRunner.call(
-          batch: batch, bucket_list: bucket_objs
+          batch: batch, bucket_list: bucket_objs, autodelete: autodelete
         )
 
         Success()

--- a/lib/collectionspace_migration_tools/batch/post_ingest_check_runner.rb
+++ b/lib/collectionspace_migration_tools/batch/post_ingest_check_runner.rb
@@ -15,9 +15,11 @@ module CollectionspaceMigrationTools
 
       # @param batch [CMT::Batch::Batch]
       # @param bucket_list [Array]
-      def initialize(batch:, bucket_list:)
+      # @param autodelete [Boolean]
+      def initialize(batch:, bucket_list:, autodelete: false)
         @batch = batch
         @bucket_list = bucket_list
+        @autodelete = autodelete
       end
 
       def call
@@ -79,7 +81,7 @@ module CollectionspaceMigrationTools
 
       private
 
-      attr_reader :batch, :bucket_list
+      attr_reader :batch, :bucket_list, :autodelete
 
       def completed_time?
         true if batch.ingest_complete_time && !batch.ingest_complete_time.empty?


### PR DESCRIPTION
Fixes bug where application fails when there are duplicates reported in `ingstat` check