### PR TITLE
Empty logstreams + mapping chronology terms

### DIFF
--- a/lib/collectionspace_migration_tools/batch/batch.rb
+++ b/lib/collectionspace_migration_tools/batch/batch.rb
@@ -83,6 +83,18 @@ module CollectionspaceMigrationTools
         str[0..-2]
       end
 
+      # @param type [:start, :end]
+      def time(type)
+        field = (type == :start) ? :ingest_start_time : :ingest_complete_time
+        val = send(field)
+        return nil if val.nil? || val.empty?
+
+        CMT::Logs.timestamp_from_datestring(val).either(
+          ->(success) { success },
+          ->(failure) {}
+        )
+      end
+
       def printable_row
         [id, action, rec_ct, mappable_rectype,
           File.basename(source_csv)].join("\t")

--- a/lib/collectionspace_migration_tools/record_mapper.rb
+++ b/lib/collectionspace_migration_tools/record_mapper.rb
@@ -20,7 +20,11 @@ module CollectionspaceMigrationTools
 
     def base_namespace
       config["ns_uri"].keys
-        .select { |ns| ns.end_with?("_common") && (ns[type_label] || ns[service_path]) }
+        .select do |ns|
+        ns.end_with?("_common") && (
+          ns[type_label] || ns[service_path] || ns[document_name]
+        )
+      end
         .first
     end
 


### PR DESCRIPTION
Fixes 2 issues: 

- when a batch is very small/fast, previous logic might not find its logstreams, then post-ingest reporting would fail
- because the chronology authority was set up with just _slight_ variation from other patterns of authority setup, the tool was unable to extract the namespace from the record mapper, so mapping of chronology records failed