### PR TITLE
Bump collectionspace-mapper version

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -27,6 +27,10 @@ These changes are merged into the `main` branch, but have not been released. Aft
 
 === Deprecated/Will break in a future version
 
+== 2.2.5 (2024-02-11)
+=== Bugfixes
+- Uses new version of `collectionspace-mapper` with a bugfix to prevent errors in reporting failures in date details mapping.
+
 == 2.2.4 (2024-02-07)
 === Added
 - Use new version of `collectionspace-mapper` that supports ingesting fields in same repeating field group as a structured date when you are ingesting structured date details for a date in that group.

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,9 @@ gem "aws-sdk-s3", "~> 1"
 gem "aws-sdk-cloudwatchlogs", "~> 1"
 gem "benchmark-memory", "~> 0.2"
 gem "collectionspace-client", branch: "main", git: "https://github.com/collectionspace/collectionspace-client.git"
-gem "collectionspace-mapper", tag: "v5.0.5", git: "https://github.com/collectionspace/collectionspace-mapper.git"
+gem "collectionspace-mapper",
+ tag: "v5.0.6",
+ git: "https://github.com/collectionspace/collectionspace-mapper.git"
 gem "collectionspace-refcache", tag: "v1.0.0", git: "https://github.com/collectionspace/collectionspace-refcache.git"
 gem "dry-monads", "~> 1.4"
 gem "dry-transaction", "~>0.13"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,10 +10,10 @@ GIT
 
 GIT
   remote: https://github.com/collectionspace/collectionspace-mapper.git
-  revision: 9587bed3208f57bab6ee773ed4681af73aec3550
-  tag: v5.0.5
+  revision: 9d66dfec79efd52eb5c999924346ffb25e63b4df
+  tag: v5.0.6
   specs:
-    collectionspace-mapper (5.0.5)
+    collectionspace-mapper (5.0.6)
       activesupport (= 7.0.4.3)
       chronic
       collectionspace-client (~> 0.15.0)
@@ -179,7 +179,7 @@ GEM
     method_source (1.0.0)
     mime-types-data (3.2021.1115)
     mini_mime (1.1.5)
-    minitest (5.22.0)
+    minitest (5.22.2)
     mock_redis (0.36.0)
       ruby2_keywords
     multi_xml (0.6.0)

--- a/lib/collectionspace_migration_tools/version.rb
+++ b/lib/collectionspace_migration_tools/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CollectionspaceMigrationTools
-  VERSION = "2.2.4"
+  VERSION = "2.2.5"
 end


### PR DESCRIPTION
Use new version of `collectionspace-mapper` with a bugfix to prevent errors in reporting failures in date details mapping.