### PR TITLE
Reset default `media_with_blob_upload_delay` value to 500ms

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -32,6 +32,7 @@ These changes are merged into the `main` branch, but have not been released. Aft
 === Changes
 
 * `csid delete --csv` option now uses `ingest_dir` if configured and only a file name is given
+* Reset default client config `media_with_blob_upload_delay` value to 500ms in accordance with the sample client config
 
 == 3.0.1 (2024-03-11)
 

--- a/lib/collectionspace_migration_tools/config/client.rb
+++ b/lib/collectionspace_migration_tools/config/client.rb
@@ -14,7 +14,7 @@ module CollectionspaceMigrationTools
           clear_cache_before_refresh: true,
           csv_delimiter: ",",
           s3_delimiter: "|",
-          media_with_blob_upload_delay: 250,
+          media_with_blob_upload_delay: 500,
           max_media_upload_threads: 5
         }
         @validator = CMT::Validate::ConfigClientContract


### PR DESCRIPTION
This is what the sample client config says the default is, and it is in line with some code I found in CollectionSpace's media handling stuff (cited in sample config).