### PR TITLE
Improve duplicate file map warning message

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,23 @@
+# noblame: Whitespace and/or formatting changes only
+f944718f3316835c959e24b7e381a23353ff1a2c
+
+# noblame: Whitespace and/or formatting changes only
+d763e44ace1ba724e20cbe47a2fdc5b834c83137
+
+# noblame: Whitespace and/or formatting changes only
+2377c3b82b77621594e5034c3fdee5cfc5cdcae2
+
+# noblame: Whitespace and/or formatting changes only
+c9e81527bc7ad889c3b5695cb5299d5a60adb0f7
+
+# noblame: Whitespace and/or formatting changes only
+c7b70837b55264c1afd3bc507d3ce08f2a580301
+
+# noblame: code formatting/whitespace/line length only
+9b777f211b668be62b6b9654cc41b31240e27992
+
+# noblame: Rubocop safe autocorrect
+91d134e230dbe9a4c4a61a1aa3c0857dfca3fb8a
+
+# noblame: Whitespace and/or formatting changes only
+f37c46b4632897e1e9f143de053a3b2c3b3e5416

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -12,6 +12,12 @@ endif::[]
 
 = Changelog
 
+== Unreleased
+
+=== Changes
+
+* Improve map error message when a non-duplicate file name cannot be saved because Mac's default file system (case insensitive) does treat it as a duplicate
+
 == 4.0.0 (2024-04-15)
 
 === Breaking

--- a/lib/collectionspace_migration_tools/csv/batch_reporter.rb
+++ b/lib/collectionspace_migration_tools/csv/batch_reporter.rb
@@ -66,7 +66,7 @@ module CollectionspaceMigrationTools
         response = result[1]
         if error == :file_already_exists
           data["CMT_errors"] =
-            "An XML record with identifier #{response.identifier} has already been written. Check for duplicates"
+            "An XML record with filename #{result[2]} has already been written. Check for duplicates"
         elsif error == :error_on_write
           data["CMT_errors"] =
             "Attempt to write XML to file raised error: #{result[2]}"

--- a/lib/collectionspace_migration_tools/xml/file_writer.rb
+++ b/lib/collectionspace_migration_tools/xml/file_writer.rb
@@ -42,8 +42,10 @@ module CollectionspaceMigrationTools
         end
       end
 
-      def check_existence(path, response)
-        return Failure([:file_already_exists, response]) if File.exist?(path)
+      def check_existence(name, path, response)
+        if File.exist?(path)
+          return Failure([:file_already_exists, response, name])
+        end
 
         Success(response)
       end
@@ -56,7 +58,7 @@ module CollectionspaceMigrationTools
 
         add_key_warnings(key, response) unless key.warnings.empty?
 
-        _checked = yield check_existence(path, response)
+        _checked = yield check_existence(file_name, path, response)
         _written = yield write_file(path, response)
 
         Success([response, file_name, key.value])


### PR DESCRIPTION
Include file name, not record identifier