### PR TITLE
Invalid config issues; deletion of vocabs by CSID

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -21,3 +21,9 @@ c7b70837b55264c1afd3bc507d3ce08f2a580301
 
 # noblame: Whitespace and/or formatting changes only
 f37c46b4632897e1e9f143de053a3b2c3b3e5416
+
+# noblame: Whitespace and/or formatting changes only
+b46bf2e2d0657978f94a3afc14d3ab8935aabaf9
+
+# noblame: Add yard todo
+a5e86f0397aa0fd33fdf29bfe946b9f53e43e30c

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,6 +14,10 @@ endif::[]
 
 == Unreleased
 
+=== Added
+
+* Support for deleting vocabularies via `thor csid delete`
+
 === Changes
 
 * Improve map error message when a non-duplicate file name cannot be saved because Mac's default file system (case insensitive) does treat it as a duplicate

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -18,6 +18,10 @@ endif::[]
 
 * Improve map error message when a non-duplicate file name cannot be saved because Mac's default file system (case insensitive) does treat it as a duplicate
 
+=== Bugfixes
+
+* Fixes issue where, if you had somehow gotten into a state where the current config was invalid, you could not switch to another config using the `thor config switch` command.
+
 == 4.0.0 (2024-04-15)
 
 === Breaking

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -20,8 +20,8 @@ endif::[]
 
 === Changes
 
+* `s3_bucket` is now optional in client configs, since this tool may be used in some cases to interact directly with an instance via its REST API, without use of Fast Import Bucket.
 * Improve map error message when a non-duplicate file name cannot be saved because Mac's default file system (case insensitive) does treat it as a duplicate
-
 === Bugfixes
 
 * Fixes issue where, if you had somehow gotten into a state where the current config was invalid, you could not switch to another config using the `thor config switch` command.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -273,7 +273,7 @@ GEM
     tabulo (3.0.1)
       tty-screen (= 0.8.2)
       unicode-display_width (~> 2.5)
-    thor (1.3.0)
+    thor (1.3.1)
     thor-hollaback (0.2.1)
       hollaback (~> 0.1)
       thor (>= 0.19.1)

--- a/Thorfile
+++ b/Thorfile
@@ -4,4 +4,5 @@ require "bundler/setup"
 require "debug"
 require_relative "lib/collectionspace_migration_tools"
 
+# @todo Is this needed with Zeitwerk?
 Dir["./lib/tasks/**/*.thor"].sort.each { |file| load file }

--- a/lib/collectionspace_migration_tools/batch/mappable.rb
+++ b/lib/collectionspace_migration_tools/batch/mappable.rb
@@ -10,8 +10,8 @@ module CollectionspaceMigrationTools
       include Dry::Monads::Do.for(:rollback_map)
 
       def rollback_map
-        rolled = yield(rollback_step("map"))
-        dir_del = yield(delete_batch_dir)
+        _rolled = yield(rollback_step("map"))
+        _dir_del = yield(delete_batch_dir)
 
         Success("Mapping data rolled back")
       end

--- a/lib/collectionspace_migration_tools/build/s3_client.rb
+++ b/lib/collectionspace_migration_tools/build/s3_client.rb
@@ -23,6 +23,8 @@ module CollectionspaceMigrationTools
       end
 
       def call
+        return Failure(:no_S3_bucket_configured) unless bucket
+
         client = yield(create_client)
         _try = yield(try(client))
 

--- a/lib/collectionspace_migration_tools/config/client.rb
+++ b/lib/collectionspace_migration_tools/config/client.rb
@@ -28,6 +28,7 @@ module CollectionspaceMigrationTools
 
       def manipulate
         add_option(:batch_config_path, nil)
+        add_option(:s3_bucket, nil)
         set_log_group_name
         add_option(:batch_csv, File.join(hash[:base_dir], "batches.csv"))
         add_media_blob_delay

--- a/lib/collectionspace_migration_tools/config/switcher.rb
+++ b/lib/collectionspace_migration_tools/config/switcher.rb
@@ -5,7 +5,7 @@ module CollectionspaceMigrationTools
     # Copies specified .yml file from `repo_dir/config` to client_config.yml
     class Switcher
       include Dry::Monads[:result]
-      include Dry::Monads::Do.for(:call)
+      include Dry::Monads::Do.for(:initialize, :call)
 
       class << self
         def call(...)
@@ -13,14 +13,12 @@ module CollectionspaceMigrationTools
         end
       end
 
-      def initialize(
-        client:,
-        target_path: CMT.config.system.config_name_file,
-        config_dir: CMT.config.system.client_config_dir
-      )
+      def initialize(client:)
         @client = client
-        @target_path = target_path
-        @source_path = File.join(config_dir, "#{client}.yml")
+
+        sysconfig = yield CMT::Config::System.call
+        @target_path = sysconfig.config_name_file
+        @source_path = File.join(sysconfig.client_config_dir, "#{client}.yml")
       end
 
       def call

--- a/lib/collectionspace_migration_tools/entity/vocabulary.rb
+++ b/lib/collectionspace_migration_tools/entity/vocabulary.rb
@@ -9,6 +9,10 @@ module CollectionspaceMigrationTools
     class Vocabulary
       include CMT::Cache::Populatable
 
+      class << self
+        def services_api_path = "vocabularies"
+      end
+
       def initialize
       end
 

--- a/lib/collectionspace_migration_tools/entity/vocabulary.rb
+++ b/lib/collectionspace_migration_tools/entity/vocabulary.rb
@@ -2,10 +2,12 @@
 
 module CollectionspaceMigrationTools
   module Entity
-    # @note There is no `duplicate` method for vocabulary terms at this point because:
-    #   - we are not batch uploading them yet, so there is no opportunity for duplicates to be
-    #     introduced by the S3/Lambda ingest process
-    #   - generally vocabularies are small enough we can take care of any duplicates manually
+    # @note There is no `duplicate` method for vocabulary terms at this point
+    #   because:
+    #   - we are not batch uploading them yet, so there is no opportunity for
+    #   duplicates to be introduced by the S3/Lambda ingest process
+    #   - generally vocabularies are small enough we can take care of any
+    #   duplicates manually
     class Vocabulary
       include CMT::Cache::Populatable
 

--- a/lib/collectionspace_migration_tools/record_types.rb
+++ b/lib/collectionspace_migration_tools/record_types.rb
@@ -95,6 +95,11 @@ module CollectionspaceMigrationTools
     end
 
     def services_api_path(rectype)
+      if rectype == "vocabulary"
+        result = CMT::Entity::Vocabulary.services_api_path
+        return Success(result)
+      end
+
       result = mappable_type_to_service_path_mapping[rectype]
     rescue => err
       msg = "#{err.message} IN #{err.backtrace[0]}"

--- a/lib/collectionspace_migration_tools/validate/config_client_contract.rb
+++ b/lib/collectionspace_migration_tools/validate/config_client_contract.rb
@@ -25,7 +25,7 @@ module CollectionspaceMigrationTools
         optional(:auto_refresh_cache_before_mapping).filled(:bool)
         optional(:clear_cache_before_refresh).filled(:bool)
         required(:csv_delimiter).filled(:string)
-        required(:s3_bucket).filled(:string)
+        optional(:s3_bucket).filled(:string)
         required(:s3_delimiter).filled(:string)
         required(:max_media_upload_threads).filled(:integer)
         required(:media_with_blob_upload_delay).filled(:integer)

--- a/lib/tasks/batch.thor
+++ b/lib/tasks/batch.thor
@@ -104,10 +104,8 @@ class Batch < Thor
   end
 
   desc "map BATCHID", "Maps a batch's source CSV data to CS XML files"
-  option :autocache, required: false, type: :boolean,
-    default: CMT.config.client.auto_refresh_cache_before_mapping
-  option :clearcache, required: false, type: :boolean,
-    default: CMT.config.client.clear_cache_before_refresh
+  option :autocache, required: false, type: :boolean
+  option :clearcache, required: false, type: :boolean
   def map(id)
     CMT::Batch.map(id, options[:autocache], options[:clearcache]).either(
       ->(success) { exit(0) },

--- a/lib/tasks/batches.thor
+++ b/lib/tasks/batches.thor
@@ -27,13 +27,13 @@ class Batches < Thor
     "Creates new batch-tracking CSV if one does not exist. Checks existing "\
     "has up-to-date format"
   def init_csv
-    path = CMT.config.client.batch_csv
     CMT::Batch::Csv::Creator.call.either(
       ->(success) {
-        puts "Wrote new file at #{path}"
+        puts "Wrote new file at #{CMT.config.client.batch_csv}"
         exit(0)
       },
       ->(failure) do
+        path = CMT.config.client.batch_csv
         FileUtils.rm(path) if File.exist?(path)
         puts failure
         exit(1)
@@ -80,10 +80,8 @@ class Batches < Thor
   end
 
   desc "map", "Maps all mappable batches to CS XML files"
-  option :autocache, required: false, type: :boolean,
-    default: CMT.config.client.auto_refresh_cache_before_mapping
-  option :clearcache, required: false, type: :boolean,
-    default: CMT.config.client.clear_cache_before_refresh
+  option :autocache, required: false, type: :boolean
+  option :clearcache, required: false, type: :boolean
   def map
     CMT::Batches.map(options[:autocache], options[:clearcache]).either(
       ->(success) { exit(0) },

--- a/sample_client_config.yml
+++ b/sample_client_config.yml
@@ -91,6 +91,9 @@ client:
   ## client. This is the bucket we upload CSXML objects into, which
   ## uses AWS Lambda to call ingest for each object. It is NOT the
   ## bucket where client media files are uploaded.
+  ##
+  ## This is optional, since there may be use cases for CMT where only
+  ## non-ingest commands are needed
   s3_bucket: "bucket_name"
 
   ## OPTIONAL SETTING

--- a/spec/collectionspace_migration_tools/validate/config_client_contract_spec.rb
+++ b/spec/collectionspace_migration_tools/validate/config_client_contract_spec.rb
@@ -66,6 +66,17 @@ RSpec.describe CollectionspaceMigrationTools::Validate::ConfigClientContract do
     end
   end
 
+  context "with no S3 bucket" do
+    let(:client_config) do
+      valid_config.delete(:s3_bucket)
+      valid_config
+    end
+
+    it "returns Success" do
+      expect(result).to be_a(Dry::Monads::Success)
+    end
+  end
+
   context "with existing batch config file" do
     let(:client_config) do
       valid_config.merge(


### PR DESCRIPTION
* Fix `thor config switch` failure if current config is invalid
* Make `s3_bucket` optional in client configs
* Support the deletion of vocabularies by CSID