### PR TITLE
fix: Handle nil redis_db values in configs

### DIFF
--- a/lib/tasks/config.thor
+++ b/lib/tasks/config.thor
@@ -33,7 +33,7 @@ class Config < Thor
       end
     end
 
-    vals.sort_by { |_key, val| val }
+    vals.compact.sort_by { |_key, val| val }
       .each { |key, val| puts "#{val}\t#{key}" }
 
     (fails == 0) ? exit(0) : exit(1)


### PR DESCRIPTION
Since functionality not dependent on caching csids and refnames was implmented, client configs no longer require a redis_db value. 

This PR fixes the fact that calling `thor config redis_dbs` fell over due to nil redis_db values for such configs.