### PR TITLE
Fix safe db error; minor tweaks; 7.2.0

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,8 +14,13 @@ endif::[]
 
 == Unreleased
 
-* `thor rr list` now can report on all mappable rectypes, not just authorities
+== 7.2.0 (2026-07-28)
 
+* `thor rr list` now can report on all mappable rectypes, not just authorities
+* Remove `thor-hollaback` dependency and related code.
+We now rely on the `at_exit` block in the base module to close database tunnel and connection as needed on any form of exit.
+*  Rename `thor tm run` to `thor tm run_plan` - without `thor-hollaback`, thor starts complaining that `run` is a protected keyword
+* `thor batch map` command now outputs both CS XML and mapping report paths separately, more clearly labeling them.
 == 7.1.0 (2026-05-13)
 
 * Skip tunnel when creating a db connection if `CMT.config.client.db_tunnel_skip` = `true`

--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,6 @@ gem "roo"
 gem "smarter_csv", "~> 1.7.4"
 gem "tabulo", "~> 3"
 gem "thor", "~> 1"
-gem "thor-hollaback", "~> 0"
 gem "zeitwerk", "~> 2.5"
 
 group :development do

--- a/lib/collectionspace_migration_tools.rb
+++ b/lib/collectionspace_migration_tools.rb
@@ -17,11 +17,8 @@ module CollectionspaceMigrationTools
     ohc omca]
 
   at_exit do
-    if CMT.connection&.open?
-      CMT.connection.close
-    else
-      CMT.tunnel&.close
-    end
+    CMT.connection.close if CMT.connection&.open?
+    CMT.tunnel&.close if CMT.tunnel&.open?
   end
 
   class << self

--- a/lib/collectionspace_migration_tools.rb
+++ b/lib/collectionspace_migration_tools.rb
@@ -105,12 +105,6 @@ module CollectionspaceMigrationTools
       exit
     end
 
-    def safe_exit
-      connection&.close
-      tunnel&.close
-      exit
-    end
-
     # @param tunnel_obj [CMT::Tunnel]
     def set_tunnel(tunnel_obj)
       return tunnel if tunnel&.open?

--- a/lib/collectionspace_migration_tools/batch/map_runner.rb
+++ b/lib/collectionspace_migration_tools/batch/map_runner.rb
@@ -59,6 +59,8 @@ module CollectionspaceMigrationTools
         report = yield(CMT::Batch::PostMapReporter.new(batch: batch,
           dir: output_dir).call)
 
+        puts "Mapper report written to: #{report}"
+
         Success(report)
       end
 

--- a/lib/collectionspace_migration_tools/batch/post_map_reporter.rb
+++ b/lib/collectionspace_migration_tools/batch/post_map_reporter.rb
@@ -71,7 +71,7 @@ module CollectionspaceMigrationTools
         _missing_term = yield(report("missing_terms", missing_term_ct))
 
         @status = "Reporting completed"
-        Success()
+        Success(report_path)
       end
 
       attr_reader :process_type, :batch, :dir, :report_path, :updated, :status

--- a/lib/collectionspace_migration_tools/cli_helpers.rb
+++ b/lib/collectionspace_migration_tools/cli_helpers.rb
@@ -1,26 +1,9 @@
 # frozen_string_literal: true
 
 module CollectionspaceMigrationTools
+  # Namespace and alias for code used/reused by Thor CLI commands
+  #   in ./lib/tasks
   module CliHelpers
     ::CMT::CliHelpers = CollectionspaceMigrationTools::CliHelpers
-
-    module_function
-
-    def db_disconnect
-      CMT.connection&.close
-      CMT.tunnel&.close
-    end
-
-    def safe_db
-      yield
-    rescue => err
-      raise err if options[:debug]
-      warn err.message
-      db_disconnect
-      exit(1)
-    else
-      db_disconnect
-      exit(0)
-    end
   end
 end

--- a/lib/collectionspace_migration_tools/csv/batch_processor.rb
+++ b/lib/collectionspace_migration_tools/csv/batch_processor.rb
@@ -34,7 +34,7 @@ module CollectionspaceMigrationTools
         _processed = yield(process)
         elap = Time.now - start_time
         puts "Mapping time: #{elap}"
-        puts "INFO: Results written to: #{output_dir}"
+        puts "INFO: CS XML written to: #{output_dir}"
 
         if term_reporter.any_terms?
           _deduplicated = yield(term_reporter.deduplicate)

--- a/lib/collectionspace_migration_tools/version.rb
+++ b/lib/collectionspace_migration_tools/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CollectionspaceMigrationTools
-  VERSION = "7.1.0"
+  VERSION = "7.2.0"
 end

--- a/lib/tasks/config.thor
+++ b/lib/tasks/config.thor
@@ -54,19 +54,6 @@ class Config < Thor
     else
       non_verbose_config_show(config)
     end
-
-    # if config.client.nil?
-    #   puts "No client config found. Try doing:\n"\
-    #     "  thor config switch {yourconfigname}. "
-    #   exit(1)
-    # end
-
-    # if options[:verbose]
-    #   pp(config)
-    # else
-    #   puts config.current_client
-    # end
-    # exit(0)
   end
 
   desc "switch CONFIG_NAME_WITHOUT_EXTENSION",

--- a/lib/tasks/pop.thor
+++ b/lib/tasks/pop.thor
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "thor"
-require "thor/hollaback"
 
 # Tasks to populate caches
 class Pop < Thor
@@ -10,7 +9,6 @@ class Pop < Thor
 
   class_option :debug, desc: "Sets up debug mode", aliases: ["-d"],
     type: :boolean
-  class_around :safe_db
 
   desc "all", "populate caches with everything"
   def all

--- a/lib/tasks/pop_auth.thor
+++ b/lib/tasks/pop_auth.thor
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "thor"
-require "thor/hollaback"
 
 # tasks to cache authority data
 class Auth < Thor
@@ -11,7 +10,6 @@ class Auth < Thor
 
   class_option :debug, desc: "Sets up debug mode", aliases: ["-d"],
     type: :boolean
-  class_around :safe_db
 
   desc "one RECTYPE",
     "populate caches with refnames and csids for ONE authority record type"

--- a/lib/tasks/pop_proc.thor
+++ b/lib/tasks/pop_proc.thor
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "thor"
-require "thor/hollaback"
 
 # tasks populating caches with object/procedure data
 class Procedure < Thor
@@ -11,7 +10,6 @@ class Procedure < Thor
 
   class_option :debug, desc: "Sets up debug mode", aliases: ["-d"],
     type: :boolean
-  class_around :safe_db
 
   desc "one RECTYPE", "populate CSID cache for ONE procedure record type"
   def one(rectype)

--- a/lib/tasks/pop_rel.thor
+++ b/lib/tasks/pop_rel.thor
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "thor"
-require "thor/hollaback"
 
 # tasks populating caches with relation data
 class Relation < Thor
@@ -11,7 +10,6 @@ class Relation < Thor
 
   class_option :debug, desc: "Sets up debug mode", aliases: ["-d"],
     type: :boolean
-  class_around :safe_db
 
   desc "ah", "populate CSID cache with authorityhierarchy relations"
   def ah

--- a/lib/tasks/refname_report.thor
+++ b/lib/tasks/refname_report.thor
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "thor"
-require "thor/hollaback"
 
 # tasks for writing authority refnames to CSV to be used as lookup tables
 class RefnameReport < Thor
@@ -9,8 +8,6 @@ class RefnameReport < Thor
   include Dry::Monads[:result]
 
   namespace :rr
-
-  class_around :safe_db
 
   option :rectypes, type: :array, aliases: "-r"
   desc "list --rectypes place-local work-cona",

--- a/lib/tasks/term_manager.thor
+++ b/lib/tasks/term_manager.thor
@@ -39,13 +39,13 @@ class TermManager < Thor
     pp(result)
   end
 
-  desc "run", "Run TermManager project"
+  desc "run_plan", "Run TermManager project"
   option :project, required: true, type: :string, aliases: "-p"
   option :instances, required: false, type: :array, aliases: "-i"
   option :term_sources, required: false, type: :array, aliases: "-s"
   option :mode, required: false, type: :string, enum: %w[force_current],
     aliases: "-m"
-  def run
+  def run_plan
     work_in_progress
 
     params = {instances: options[:instances],


### PR DESCRIPTION
Fixes "safe db" error by removing dependency on `thor-hollaback` gem. 
We now rely on the `at_exit` block in the base module to close database tunnel and connection as needed on any form of exit.

Rename `thor tm run` to `thor tm run_plan` - without `thor-hollaback`, thor starts complaining that `run` is a protected keyword

`thor batch map` command now outputs both CS XML and mapping report paths separately, more clearly labeling them.