### PR TITLE
Make `thor rr list` output path configurable

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,6 +14,8 @@ endif::[]
 
 == Unreleased
 
+* Add `path` option to `thor rr list` command
+
 == 7.2.0 (2026-07-28)
 
 * `thor rr list` now can report on all mappable rectypes, not just authorities

--- a/lib/collectionspace_migration_tools/refname_report.rb
+++ b/lib/collectionspace_migration_tools/refname_report.rb
@@ -11,6 +11,7 @@ module CollectionspaceMigrationTools
 
     # @param rectypes [Array<#cacheable_data_query>]
     def write(rectypes)
+    # @param path [String] location to write output
       data = yield refname_data(rectypes)
       path = yield refname_data_path
       _written = yield write_blob_data_report(data, path)
@@ -19,6 +20,7 @@ module CollectionspaceMigrationTools
     end
 
     # @param rectypes [Array<#cacheable_data_query>]
+    # @return [Array<Hash>] Dry::Monads::Success wrapping rows of cacheable data
     def refname_data(rectypes)
       data = rectypes.map do |rectype|
         query = yield rectype.cacheable_data_query

--- a/lib/collectionspace_migration_tools/refname_report.rb
+++ b/lib/collectionspace_migration_tools/refname_report.rb
@@ -30,7 +30,7 @@ module CollectionspaceMigrationTools
       Success(data.flatten)
     end
 
-    def refname_data_path
+    def default_refname_data_path
       result = File.join(
         CMT.config.client.base_dir,
         "refname_data.csv"

--- a/lib/collectionspace_migration_tools/refname_report.rb
+++ b/lib/collectionspace_migration_tools/refname_report.rb
@@ -10,10 +10,12 @@ module CollectionspaceMigrationTools
     module_function
 
     # @param rectypes [Array<#cacheable_data_query>]
-    def write(rectypes)
     # @param path [String] location to write output
+    def write(rectypes:, path:)
+      dir = File.dirname(path)
+      FileUtils.mkdir_p(dir) unless Dir.exist?(dir)
+
       data = yield refname_data(rectypes)
-      path = yield refname_data_path
       _written = yield write_blob_data_report(data, path)
 
       Success()

--- a/lib/tasks/refname_report.thor
+++ b/lib/tasks/refname_report.thor
@@ -14,6 +14,8 @@ class RefnameReport < Thor
   option :rectypes,
     type: :array,
     aliases: "-r",
+    required: true,
+    desc: "Mappable record types for which to pull refname/CSID info",
     banner: "person-local person-ulan"
   def list
     # rectypes = options[:rectypes].map do |rectype|

--- a/lib/tasks/refname_report.thor
+++ b/lib/tasks/refname_report.thor
@@ -9,9 +9,12 @@ class RefnameReport < Thor
 
   namespace :rr
 
-  option :rectypes, type: :array, aliases: "-r"
-  desc "list --rectypes place-local work-cona",
+  desc "list",
     "write refname report that includes terms in listed authority record types"
+  option :rectypes,
+    type: :array,
+    aliases: "-r",
+    banner: "person-local person-ulan"
   def list
     # rectypes = options[:rectypes].map do |rectype|
     #   CMT::Entity::Authority.from_str(rectype)

--- a/lib/tasks/refname_report.thor
+++ b/lib/tasks/refname_report.thor
@@ -18,9 +18,6 @@ class RefnameReport < Thor
     desc: "Mappable record types for which to pull refname/CSID info",
     banner: "person-local person-ulan"
   def list
-    # rectypes = options[:rectypes].map do |rectype|
-    #   CMT::Entity::Authority.from_str(rectype)
-    # end
     rectypes = options[:rectypes].map do |rectype|
       CMT::RecordTypes.to_obj(rectype)
     end

--- a/lib/tasks/refname_report.thor
+++ b/lib/tasks/refname_report.thor
@@ -17,6 +17,12 @@ class RefnameReport < Thor
     required: true,
     desc: "Mappable record types for which to pull refname/CSID info",
     banner: "person-local person-ulan"
+  option :outputpath,
+    type: :string,
+    aliases: "-o",
+    required: false,
+    desc: "Path where result will be written. Should be a .csv",
+    default: CMT::RefnameReport.default_refname_data_path.value!
   def list
     rectypes = options[:rectypes].map do |rectype|
       CMT::RecordTypes.to_obj(rectype)
@@ -24,6 +30,9 @@ class RefnameReport < Thor
     rectypes.select(&:failure?)
       .each { |rt| puts rt.failure }
 
-    CMT::RefnameReport.write(rectypes.select(&:success?).map(&:value!))
+    CMT::RefnameReport.write(
+      rectypes: rectypes.select(&:success?).map(&:value!),
+      path: options[:outputpath]
+    )
   end
 end

--- a/spec/collectionspace_migration_tools/batch/csid_cache_dependency_identifier_spec.rb
+++ b/spec/collectionspace_migration_tools/batch/csid_cache_dependency_identifier_spec.rb
@@ -2,9 +2,7 @@
 
 require_relative "../../spec_helper"
 
-# rubocop:disable Layout/LineLength
-RSpec.describe CollectionspaceMigrationTools::Batch::CsidCacheDependencyIdentifier do
-  # rubocop:enable Layout/LineLength
+RSpec.describe CMT::Batch::CsidCacheDependencyIdentifier do
   let(:klass) { described_class.new(path: path, mapper: mapper) }
 
   describe "#call" do

--- a/spec/collectionspace_migration_tools/build/data_handler_spec.rb
+++ b/spec/collectionspace_migration_tools/build/data_handler_spec.rb
@@ -3,7 +3,12 @@
 require_relative "../../spec_helper"
 
 RSpec.describe CollectionspaceMigrationTools::Build::DataHandler do
-  before(:all) { setup_mapping }
+  before(:each) do
+    CMT.config.client.batch_config_path = File.join(
+      fixtures_base, "client_batch_config.json"
+    )
+  end
+  after(:each) { CMT.config.client.batch_config_path = nil }
 
   describe "#call" do
     let(:mapper) { CMT::Parse::RecordMapper.call("collectionobject").value! }

--- a/spec/collectionspace_migration_tools/configuration_spec.rb
+++ b/spec/collectionspace_migration_tools/configuration_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CollectionspaceMigrationTools::Configuration do
     it "returns Configuration object" do
       expect(result).to be_a(CMT::Configuration)
       expect(result.client.base_uri).to eq(
-        "https://core.dev.collectionspace.org/cspace-services"
+        "https://anthro.dev.collectionspace.org/cspace-services"
       )
       expect(result.client.batch_config_path).to be_nil
       expect(result.client.batch_csv).to eq(File.join(result.client.base_dir,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,6 +37,11 @@ RSpec.configure do |config|
     # CMT.reset_config
   end
 
+  config.after(:suite) do
+    path = File.join(Bundler.root, "fixturesdir")
+    FileUtils.rm_rf(path) if Dir.exist?(path)
+  end
+
   config.expect_with(:rspec) do |expectations|
     expectations.syntax = :expect
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,11 +30,11 @@ RSpec.configure do |config|
       File.join(fixtures_base, "sys_config_w_term_manager.yml")
     ENV["COLLECTIONSPACE_MIGRATION_TOOLS_CLIENT_CONFIG"] =
       File.join(fixtures_base, "config", "sample.yml")
+    CMT.reset_config
   end
   config.after(:each) do
     ENV.delete("COLLECTIONSPACE_MIGRATION_TOOLS_SYSTEM_CONFIG")
     ENV.delete("COLLECTIONSPACE_MIGRATION_TOOLS_CLIENT_CONFIG")
-    # CMT.reset_config
   end
 
   config.after(:suite) do

--- a/spec/support/fixtures/config/sample.yml
+++ b/spec/support/fixtures/config/sample.yml
@@ -1,5 +1,5 @@
-base_uri: https://core.dev.collectionspace.org/cspace-services
-username: admin@core.collectionspace.org
+base_uri: https://anthro.dev.collectionspace.org/cspace-services
+username: admin@anthro.collectionspace.org
 password: Administrator
 page_size: 50
 


### PR DESCRIPTION
The title was the main point of this PR. 

Then, I got 44 errors running `rspec --seed 45772` before pushing this branch up. Given that I'd changed NOTHING that should cause all those internal tests to fail, it was pretty clear this was an order-dependent issue caused by application config not being cleared/reset properly in between tests. So that particular issue is fixed too. (This has been a whack-a-mole problem in this app/test suite because the way the app config gets set up for real use is a pain to change for different tests)

Note: because this app requires cspace-hosted-instance-access (CHIA) AND makes a lot of assumptions about file locations and stuff outside the application directory, we do not run GitHub Actions tests on PRs in this one.