### PR TITLE
fix newline stripping in config filename parsing

### DIFF
--- a/lib/collectionspace_migration_tools/config.rb
+++ b/lib/collectionspace_migration_tools/config.rb
@@ -36,7 +36,7 @@ module CollectionspaceMigrationTools
         yield CMT::Config::System.call
       end
       path = system.config_name_file
-      content = File.read(path)
+      content = File.read(path).strip
       if content.empty?
         return Failure(CMT::Failure.new(
           context: "#{self.class.name}.#{__callee__}",

--- a/lib/collectionspace_migration_tools/configuration.rb
+++ b/lib/collectionspace_migration_tools/configuration.rb
@@ -39,7 +39,9 @@ module CollectionspaceMigrationTools
       )
     end
 
-    def current_client = File.read(File.expand_path(system.config_name_file))
+    def current_client
+      File.read(File.expand_path(system.config_name_file)).strip
+    end
 
     def add_config(type, hash)
       if type == :term_manager


### PR DESCRIPTION
Minor bug fix: added newline stripping in two places where we read the filename from the system config file. Was breaking on `thor config switch [anything]`.