### PR TITLE
add timeout to ssh tunnel in case of trust prompt or bad key

### DIFF
--- a/lib/collectionspace_migration_tools/config/system.rb
+++ b/lib/collectionspace_migration_tools/config/system.rb
@@ -13,6 +13,8 @@ module CollectionspaceMigrationTools
           db_port: 5432,
           db_connect_host: "localhost",
           db_tunnel_connection_pause: 3,
+          db_tunnel_initial_connection_timeout: 30,
+          db_tunnel_initial_connection_polling_interval: 2.5,
           csv_chunk_size: 50,
           max_threads: 10,
           max_processes: 6,

--- a/lib/collectionspace_migration_tools/database/open_tunnel.rb
+++ b/lib/collectionspace_migration_tools/database/open_tunnel.rb
@@ -7,11 +7,6 @@ module CollectionspaceMigrationTools
   module Database
     # Opens SSH tunnel so we can connect to database through bastion server
     class OpenTunnel
-      # How long to wait for the SSH tunnel to connect (allows users to respond to trust prompt)
-      TUNNEL_TIMEOUT = 30
-      # How often to check whether it's connected
-      TUNNEL_POLLING_INTERVAL = 0.25
-
       class << self
         include Dry::Monads[:result]
 
@@ -65,7 +60,10 @@ module CollectionspaceMigrationTools
 
         def wait_for_tunnel(wait_thread)
           port = CMT.config.system.db_port
-          deadline = Time.now + TUNNEL_TIMEOUT
+          timeout = CMT.config.system.db_tunnel_initial_connection_timeout
+          interval = CMT.config.system
+            .db_tunnel_initial_connection_polling_interval
+          deadline = Time.now + timeout
 
           puts "Waiting for SSH tunnel to open on port #{port}."
 
@@ -79,12 +77,13 @@ module CollectionspaceMigrationTools
               TCPSocket.new("127.0.0.1", port).close
               return Success()
             rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT
-              sleep TUNNEL_POLLING_INTERVAL
+              sleep interval
             end
           end
 
           Failure(CMT::Failure.new(context: "#{name}.#{__callee__}",
-            message: "Timed out after #{TUNNEL_TIMEOUT}s waiting for SSH tunnel on port #{port} to open."))
+            message: "Timed out after #{timeout}s waiting for SSH"\
+              " tunnel on port #{port} to open."))
         end
       end
     end

--- a/lib/collectionspace_migration_tools/database/open_tunnel.rb
+++ b/lib/collectionspace_migration_tools/database/open_tunnel.rb
@@ -1,11 +1,17 @@
 # frozen_string_literal: true
 
 require "dry/monads"
+require "socket"
 
 module CollectionspaceMigrationTools
   module Database
     # Opens SSH tunnel so we can connect to database through bastion server
     class OpenTunnel
+      # How long to wait for the SSH tunnel to connect (allows users to respond to trust prompt)
+      TUNNEL_TIMEOUT = 30
+      # How often to check whether it's connected
+      TUNNEL_POLLING_INTERVAL = 0.25
+
       class << self
         include Dry::Monads[:result]
 
@@ -36,12 +42,18 @@ module CollectionspaceMigrationTools
 
         def open_tunnel(tunnel_command)
           tunnel_pid = spawn(tunnel_command)
-          Process.detach(tunnel_pid)
+
+          # Instead of immediately detaching the process (which steamrolls the
+          # trust prompt), wait for the tunnel to come up first.
+          wait_thread = Process.detach(tunnel_pid)
 
           unless tunnel_pid.is_a?(Integer)
             return Failure(CMT::Failure.new(context: "#{name}.#{__callee__}",
               message: "Tunnel not created"))
           end
+
+          ready = wait_for_tunnel(wait_thread)
+          return ready if ready.failure?
 
           tunnel_obj = CMT::Tunnel.new(tunnel_pid, tunnel_command)
           CMT.set_tunnel(tunnel_obj)
@@ -49,6 +61,30 @@ module CollectionspaceMigrationTools
         rescue => err
           Failure(CMT::Failure.new(context: "#{name}.#{__callee__}",
             message: err))
+        end
+
+        def wait_for_tunnel(wait_thread)
+          port = CMT.config.system.db_port
+          deadline = Time.now + TUNNEL_TIMEOUT
+
+          puts "Waiting for SSH tunnel to open on port #{port}."
+
+          until Time.now > deadline
+            unless wait_thread.alive?
+              return Failure(CMT::Failure.new(context: "#{name}.#{__callee__}",
+                message: "SSH tunnel process exited!"))
+            end
+
+            begin
+              TCPSocket.new("127.0.0.1", port).close
+              return Success()
+            rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT
+              sleep TUNNEL_POLLING_INTERVAL
+            end
+          end
+
+          Failure(CMT::Failure.new(context: "#{name}.#{__callee__}",
+            message: "Timed out after #{TUNNEL_TIMEOUT}s waiting for SSH tunnel on port #{port} to open."))
         end
       end
     end

--- a/lib/collectionspace_migration_tools/validate/config_system_contract.rb
+++ b/lib/collectionspace_migration_tools/validate/config_system_contract.rb
@@ -17,6 +17,8 @@ module CollectionspaceMigrationTools
         required(:db_port).filled(:integer)
         required(:db_connect_host).filled(:string)
         required(:db_tunnel_connection_pause).filled(:integer)
+        required(:db_tunnel_initial_connection_timeout).filled(:integer)
+        required(:db_tunnel_initial_connection_polling_interval).filled(:float)
         optional(:aws_media_ingest_profile).maybe(:string)
         optional(:term_manager_config_dir).maybe(:string)
       end

--- a/sample_system_config.yml
+++ b/sample_system_config.yml
@@ -39,6 +39,15 @@ bastion_user: yourusername
 #   will get interpreted as 70.**
 # cs_app_version: "8_1_1"
 
+# How long to wait for the SSH tunnel to be usable. This timeout exists
+#   mainly so that users can respond to trust prompts or reason about 
+#   errors caused by bad credentials. It's logically distinct from the
+#   database timeout (below), which is used after the tunnel is 
+#   connected. It probably won't be necessary to change these values,
+#   but they can be adjusted if required.
+# db_tunnel_initial_connection_timeout: 30
+# db_tunnel_initial_connection_polling_interval: 2.5
+
 # Number of seconds to wait between getting new DB tunnel and
 #   attempting to get database connection. Will be set by default, but
 #   can be overridden by uncommenting in your config. Uncomment the

--- a/spec/collectionspace_migration_tools/config/system_spec.rb
+++ b/spec/collectionspace_migration_tools/config/system_spec.rb
@@ -42,6 +42,33 @@ RSpec.describe CollectionspaceMigrationTools::Config::System do
     end
   end
 
+  context "when db_tunnel_initial_connection_timeout overridden" do
+    let(:config) do
+      data = sys_config_hash.dup
+      data[:db_tunnel_initial_connection_timeout] = 45
+      data
+    end
+
+    it "returns Success" do
+      expect(result).to be_a(Dry::Monads::Success)
+      expect(result.value!.db_tunnel_initial_connection_timeout).to eq(45)
+    end
+  end
+
+  context "when db_tunnel_initial_connection_polling_interval overridden" do
+    let(:config) do
+      data = sys_config_hash.dup
+      data[:db_tunnel_initial_connection_polling_interval] = 0.5
+      data
+    end
+
+    it "returns Success" do
+      expect(result).to be_a(Dry::Monads::Success)
+      expect(result.value!.db_tunnel_initial_connection_polling_interval).to\
+       eq(0.5)
+    end
+  end
+
   context "when missing system client_config_dir setting" do
     let(:config) do
       data = sys_config_hash.dup


### PR DESCRIPTION
When I was debugging my bastion problem, I also ran into an edge case in the logic of `open_tunnel.rb`. If the user sees an ssh trust prompt (host wasn't known, for example), the software doesn't wait for the user's response because it has already detached the process and is trying to use the tunnel anyway. This specific scenario tripped me up -- first connection / unknown host connection didn't wait for the trust prompt, even though I also had an unrelated auth problem. This is a small fix that doesn't change the basic functionality, just wraps it in a a loop that expires when now = calculated timeout, polling the status of the tunnel at specified intervals. Any failure here is now a little louder, which may help others. Tested and working, but I welcome Ruby lessons.